### PR TITLE
Steam and D2RMM Integration

### DIFF
--- a/ReimaginedLauncher/MainWindow.axaml
+++ b/ReimaginedLauncher/MainWindow.axaml
@@ -83,7 +83,7 @@
                         <ListBoxItem x:Name="BackupsNavItem" Tag="Backups" Content="Backups" />
                         <ListBoxItem x:Name="SettingsNavItem" Tag="Settings" Content="Settings" />
                         <ListBoxItem x:Name="ModTweaksNavItem" Tag="ModTweaks" Content="Mod Tweaks" />
-                        <ListBoxItem x:Name="UpdateNavItem" Tag="Update" Content="Update" />
+                        <ListBoxItem x:Name="UpdateNavItem" Tag="Update" Content="Install/Update" />
                     </ListBox>
                 </DockPanel>
 

--- a/ReimaginedLauncher/MainWindow.axaml
+++ b/ReimaginedLauncher/MainWindow.axaml
@@ -15,6 +15,10 @@
 >
     <Window.Styles>
         <materialIcons:MaterialIconStyles />
+        <Style Selector="NotificationCard TextBlock">
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="TextTrimming" Value="None" />
+        </Style>
     </Window.Styles>
     <LayoutTransformControl x:Name="RootScaleControl">
         <Grid x:Name="RootGrid"

--- a/ReimaginedLauncher/MainWindow.axaml.cs
+++ b/ReimaginedLauncher/MainWindow.axaml.cs
@@ -441,27 +441,51 @@ public partial class MainWindow : Window
         _localModVersion = "Unknown";
         IsLocalModDetected = false;
 
-        var installDir = installDirectory ?? Settings.InstallDirectory;
-        if (!string.IsNullOrWhiteSpace(installDir))
+        var profile = Settings.CurrentProfile;
+        if (profile.Type == InstallationType.D2RMM)
         {
-            var modRootDirectory = Path.Combine(installDir, "mods", "Reimagined");
-            var modInfoPath = Path.Combine(modRootDirectory, "modinfo.json");
-            var modInfoPathInMpq = Path.Combine(modRootDirectory, "Reimagined.mpq", "modinfo.json");
-            var layoutsDir = Path.Combine(
-                modRootDirectory,
-                "Reimagined.mpq", "data", "global", "ui", "layouts"
-            );
+            if (!string.IsNullOrWhiteSpace(profile.InstallDirectory))
+            {
+                var modPath = Path.Combine(profile.InstallDirectory, "Reimagined.mpq");
+                var modInfoPath = Path.Combine(modPath, "modinfo.json");
+                var layoutsDir = Path.Combine(modPath, "data", "global", "ui", "layouts");
 
-            var panel = CharacterSelectPanelService.FromJson(layoutsDir);
-            var panelVersion = panel?.GetModVersion();
-            var modInfoVersion = TryGetVersionFromModInfo(modInfoPath) ?? TryGetVersionFromModInfo(modInfoPathInMpq);
-            _localModVersion = !string.IsNullOrWhiteSpace(panelVersion) && !panelVersion.Equals("Unknown", StringComparison.OrdinalIgnoreCase)
-                ? panelVersion
-                : !string.IsNullOrWhiteSpace(modInfoVersion)
-                    ? modInfoVersion
-                    : "Unknown";
+                IsLocalModDetected = Directory.Exists(modPath);
 
-            IsLocalModDetected = Directory.Exists(modRootDirectory) || File.Exists(modInfoPath) || File.Exists(modInfoPathInMpq);
+                var panel = CharacterSelectPanelService.FromJson(layoutsDir);
+                var panelVersion = panel?.GetModVersion();
+                var modInfoVersion = TryGetVersionFromModInfo(modInfoPath);
+                _localModVersion = !string.IsNullOrWhiteSpace(panelVersion) && !panelVersion.Equals("Unknown", StringComparison.OrdinalIgnoreCase)
+                    ? panelVersion
+                    : !string.IsNullOrWhiteSpace(modInfoVersion)
+                        ? modInfoVersion
+                        : "Unknown";
+            }
+        }
+        else
+        {
+            var installDir = installDirectory ?? Settings.InstallDirectory;
+            if (!string.IsNullOrWhiteSpace(installDir))
+            {
+                var modRootDirectory = Path.Combine(installDir, "mods", "Reimagined");
+                var modInfoPath = Path.Combine(modRootDirectory, "modinfo.json");
+                var modInfoPathInMpq = Path.Combine(modRootDirectory, "Reimagined.mpq", "modinfo.json");
+                var layoutsDir = Path.Combine(
+                    modRootDirectory,
+                    "Reimagined.mpq", "data", "global", "ui", "layouts"
+                );
+
+                var panel = CharacterSelectPanelService.FromJson(layoutsDir);
+                var panelVersion = panel?.GetModVersion();
+                var modInfoVersion = TryGetVersionFromModInfo(modInfoPath) ?? TryGetVersionFromModInfo(modInfoPathInMpq);
+                _localModVersion = !string.IsNullOrWhiteSpace(panelVersion) && !panelVersion.Equals("Unknown", StringComparison.OrdinalIgnoreCase)
+                    ? panelVersion
+                    : !string.IsNullOrWhiteSpace(modInfoVersion)
+                        ? modInfoVersion
+                        : "Unknown";
+
+                IsLocalModDetected = Directory.Exists(modRootDirectory) || File.Exists(modInfoPath) || File.Exists(modInfoPathInMpq);
+            }
         }
 
         if (Dispatcher.UIThread.CheckAccess())

--- a/ReimaginedLauncher/Utilities/AppSettings.cs
+++ b/ReimaginedLauncher/Utilities/AppSettings.cs
@@ -1,19 +1,25 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace ReimaginedLauncher.Utilities;
 
-public class AppSettings
+public enum InstallationType
 {
-    public double UiScale { get; set; } = 1.0;
-    public int LastReadAnnouncementNumber { get; set; }
+    BattleNet,
+    Steam,
+    D2RMM
+}
+
+public class InstallationProfile
+{
+    public InstallationType Type { get; set; }
     public string? InstallDirectory { get; set; }
+    public string? SteamDirectory { get; set; }
     public bool IsInstallDirectoryValidated { get; set; }
     public string? BackupSaveDirectory { get; set; }
     public bool AutomaticBackupsEnabled { get; set; } = true;
     public int BackupIntervalMinutes { get; set; } = 60;
     public int BackupAmount { get; set; } = 10;
-    public string? NexusModsSSOApiKey { get; set; }
-    public bool? NexusPremiumDownloadAccess { get; set; }
     public bool NoSound { get; set; }
     public bool NoRumble { get; set; }
     public bool ForceDesktop { get; set; }
@@ -30,4 +36,59 @@ public class AppSettings
     public bool RemoveSplashVfx { get; set; }
     public List<PluginRegistration> Plugins { get; set; } = [];
     public bool MakeTooltipBackgroundOpaque { get; set; }
+}
+
+public class AppSettings
+{
+    public double UiScale { get; set; } = 1.0;
+    public int LastReadAnnouncementNumber { get; set; }
+    public string? NexusModsSSOApiKey { get; set; }
+    public bool? NexusPremiumDownloadAccess { get; set; }
+    
+    public List<InstallationProfile> Profiles { get; set; } = [];
+    public int SelectedProfileIndex { get; set; }
+
+    [JsonIgnore]
+    public InstallationProfile CurrentProfile
+    {
+        get
+        {
+            if (Profiles.Count == 0)
+            {
+                // Default profiles
+                Profiles.Add(new InstallationProfile { Type = InstallationType.BattleNet });
+                Profiles.Add(new InstallationProfile { Type = InstallationType.Steam });
+                Profiles.Add(new InstallationProfile { Type = InstallationType.D2RMM, AutomaticBackupsEnabled = false });
+            }
+            if (SelectedProfileIndex < 0 || SelectedProfileIndex >= Profiles.Count)
+            {
+                SelectedProfileIndex = 0;
+            }
+            return Profiles[SelectedProfileIndex];
+        }
+    }
+
+    // Proxy properties for backward compatibility
+    [JsonIgnore] public string? InstallDirectory { get => CurrentProfile.InstallDirectory; set => CurrentProfile.InstallDirectory = value; }
+    [JsonIgnore] public bool IsInstallDirectoryValidated { get => CurrentProfile.IsInstallDirectoryValidated; set => CurrentProfile.IsInstallDirectoryValidated = value; }
+    [JsonIgnore] public string? BackupSaveDirectory { get => CurrentProfile.BackupSaveDirectory; set => CurrentProfile.BackupSaveDirectory = value; }
+    [JsonIgnore] public bool AutomaticBackupsEnabled { get => CurrentProfile.AutomaticBackupsEnabled; set => CurrentProfile.AutomaticBackupsEnabled = value; }
+    [JsonIgnore] public int BackupIntervalMinutes { get => CurrentProfile.BackupIntervalMinutes; set => CurrentProfile.BackupIntervalMinutes = value; }
+    [JsonIgnore] public int BackupAmount { get => CurrentProfile.BackupAmount; set => CurrentProfile.BackupAmount = value; }
+    [JsonIgnore] public bool NoSound { get => CurrentProfile.NoSound; set => CurrentProfile.NoSound = value; }
+    [JsonIgnore] public bool NoRumble { get => CurrentProfile.NoRumble; set => CurrentProfile.NoRumble = value; }
+    [JsonIgnore] public bool ForceDesktop { get => CurrentProfile.ForceDesktop; set => CurrentProfile.ForceDesktop = value; }
+    [JsonIgnore] public bool ResetOfflineMaps { get => CurrentProfile.ResetOfflineMaps; set => CurrentProfile.ResetOfflineMaps = value; }
+    [JsonIgnore] public bool EnableRespec { get => CurrentProfile.EnableRespec; set => CurrentProfile.EnableRespec = value; }
+    [JsonIgnore] public int? PlayersCount { get => CurrentProfile.PlayersCount; set => CurrentProfile.PlayersCount = value; }
+    [JsonIgnore] public int SkillPointsPerLevel { get => CurrentProfile.SkillPointsPerLevel; set => CurrentProfile.SkillPointsPerLevel = value; }
+    [JsonIgnore] public int AttributesPerLevel { get => CurrentProfile.AttributesPerLevel; set => CurrentProfile.AttributesPerLevel = value; }
+    [JsonIgnore] public int MaxSkillLevel { get => CurrentProfile.MaxSkillLevel; set => CurrentProfile.MaxSkillLevel = value; }
+    [JsonIgnore] public int NormalResistPenalty { get => CurrentProfile.NormalResistPenalty; set => CurrentProfile.NormalResistPenalty = value; }
+    [JsonIgnore] public int NightmareResistPenalty { get => CurrentProfile.NightmareResistPenalty; set => CurrentProfile.NightmareResistPenalty = value; }
+    [JsonIgnore] public int HellResistPenalty { get => CurrentProfile.HellResistPenalty; set => CurrentProfile.HellResistPenalty = value; }
+    [JsonIgnore] public bool RemovePaladinAuraSound { get => CurrentProfile.RemovePaladinAuraSound; set => CurrentProfile.RemovePaladinAuraSound = value; }
+    [JsonIgnore] public bool RemoveSplashVfx { get => CurrentProfile.RemoveSplashVfx; set => CurrentProfile.RemoveSplashVfx = value; }
+    [JsonIgnore] public List<PluginRegistration> Plugins { get => CurrentProfile.Plugins; set => CurrentProfile.Plugins = value; }
+    [JsonIgnore] public bool MakeTooltipBackgroundOpaque { get => CurrentProfile.MakeTooltipBackgroundOpaque; set => CurrentProfile.MakeTooltipBackgroundOpaque = value; }
 }

--- a/ReimaginedLauncher/Utilities/AppSettings.cs
+++ b/ReimaginedLauncher/Utilities/AppSettings.cs
@@ -92,4 +92,5 @@ public class AppSettings
     [JsonIgnore] public bool RemoveSplashVfx { get => CurrentProfile.RemoveSplashVfx; set => CurrentProfile.RemoveSplashVfx = value; }
     [JsonIgnore] public List<PluginRegistration> Plugins { get => CurrentProfile.Plugins; set => CurrentProfile.Plugins = value; }
     [JsonIgnore] public bool MakeTooltipBackgroundOpaque { get => CurrentProfile.MakeTooltipBackgroundOpaque; set => CurrentProfile.MakeTooltipBackgroundOpaque = value; }
+    [JsonIgnore] public bool RemoveHelmetVisual { get => CurrentProfile.RemoveHelmetVisual; set => CurrentProfile.RemoveHelmetVisual = value; }
 }

--- a/ReimaginedLauncher/Utilities/GameLauncherService.cs
+++ b/ReimaginedLauncher/Utilities/GameLauncherService.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,11 +37,31 @@ public class GameLauncherService
         _detectionCts = new CancellationTokenSource();
         var token = _detectionCts.Token;
 
-        if (InstallDirectoryValidator.IsValidInstallDirectory(MainWindow.Settings.InstallDirectory))
+        var settings = MainWindow.Settings;
+        var currentProfile = settings.CurrentProfile;
+
+        // If current profile already has a valid directory, just normalise and return
+        if (InstallDirectoryValidator.IsValidInstallDirectory(currentProfile.InstallDirectory))
         {
-            MainWindow.Settings.InstallDirectory =
-                InstallDirectoryValidator.NormalizeInstallDirectory(MainWindow.Settings.InstallDirectory);
-            MainWindow.Settings.IsInstallDirectoryValidated = true;
+            currentProfile.InstallDirectory =
+                InstallDirectoryValidator.NormalizeInstallDirectory(currentProfile.InstallDirectory);
+            currentProfile.IsInstallDirectoryValidated = true;
+
+            if (currentProfile.Type == InstallationType.BattleNet)
+            {
+                var detectedType = DetectInstallationType(currentProfile.InstallDirectory!);
+                if (detectedType != InstallationType.BattleNet)
+                {
+                    currentProfile.Type = detectedType;
+                    if (detectedType == InstallationType.Steam)
+                        currentProfile.SteamDirectory = FindSteamExecutable(currentProfile.InstallDirectory);
+                }
+            }
+
+            // Still check the other default path to populate the sibling profile
+            PopulateDefaultPaths(settings);
+            _ = SettingsManager.SaveAsync(settings);
+
             onComplete?.Invoke();
             return;
         }
@@ -48,21 +69,91 @@ public class GameLauncherService
         IsDetecting = true;
         try
         {
-            var detectedExecutablePath = await Task.Run(() => FindD2RExecutable(token), token);
-
+            // ── Phase 1: check both well-known default locations ──
+            var foundPaths = await Task.Run(() => CheckDefaultPaths(token), token);
             if (token.IsCancellationRequested) return;
 
-            if (!string.IsNullOrEmpty(detectedExecutablePath))
+            bool anyFound = false;
+
+            if (foundPaths.BattleNetPath is not null)
             {
-                MainWindow.Settings.InstallDirectory =
-                    InstallDirectoryValidator.NormalizeInstallDirectory(detectedExecutablePath);
-                MainWindow.Settings.IsInstallDirectoryValidated = true;
-                _ = SettingsManager.SaveAsync(MainWindow.Settings);
+                var bnetProfile = GetProfileByType(settings, InstallationType.BattleNet);
+                if (!bnetProfile.IsInstallDirectoryValidated)
+                {
+                    bnetProfile.InstallDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(foundPaths.BattleNetPath);
+                    bnetProfile.IsInstallDirectoryValidated = true;
+                    anyFound = true;
+                }
+            }
+
+            if (foundPaths.SteamPath is not null)
+            {
+                var steamProfile = GetProfileByType(settings, InstallationType.Steam);
+                if (!steamProfile.IsInstallDirectoryValidated)
+                {
+                    steamProfile.InstallDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(foundPaths.SteamPath);
+                    steamProfile.IsInstallDirectoryValidated = true;
+                    steamProfile.SteamDirectory = FindSteamExecutable(steamProfile.InstallDirectory);
+                    anyFound = true;
+                }
+            }
+
+            // If the current profile was populated by the default-path check, we're done
+            if (currentProfile.IsInstallDirectoryValidated)
+            {
+                if (anyFound)
+                {
+                    NotifyDetectionResults(foundPaths);
+                    _ = SettingsManager.SaveAsync(settings);
+                }
+                onComplete?.Invoke();
+                return;
+            }
+
+            // ── Phase 2: fall back to full-disk search ──
+            if (!anyFound)
+            {
+                var detectedExecutablePath = await Task.Run(() => FindD2RExecutable(token), token);
+                if (token.IsCancellationRequested) return;
+
+                if (!string.IsNullOrEmpty(detectedExecutablePath))
+                {
+                    var normalised = InstallDirectoryValidator.NormalizeInstallDirectory(detectedExecutablePath);
+                    var detectedType = DetectInstallationType(normalised!);
+                    var targetProfile = GetProfileByType(settings, detectedType);
+
+                    targetProfile.InstallDirectory = normalised;
+                    targetProfile.IsInstallDirectoryValidated = true;
+                    if (detectedType == InstallationType.Steam)
+                        targetProfile.SteamDirectory = FindSteamExecutable(targetProfile.InstallDirectory);
+
+                    // Make sure the current profile points to the one we just found
+                    settings.SelectedProfileIndex = settings.Profiles.IndexOf(targetProfile);
+
+                    _ = SettingsManager.SaveAsync(settings);
+                }
+                else
+                {
+                    currentProfile.IsInstallDirectoryValidated = false;
+                    Notifications.SendNotification("D2R.exe not found");
+                }
             }
             else
             {
-                MainWindow.Settings.IsInstallDirectoryValidated = false;
-                Notifications.SendNotification("D2R.exe not found");
+                // Default paths found something — select the first validated non-D2RMM profile
+                if (!currentProfile.IsInstallDirectoryValidated)
+                {
+                    for (int i = 0; i < settings.Profiles.Count; i++)
+                    {
+                        if (settings.Profiles[i].IsInstallDirectoryValidated && settings.Profiles[i].Type != InstallationType.D2RMM)
+                        {
+                            settings.SelectedProfileIndex = i;
+                            break;
+                        }
+                    }
+                }
+                NotifyDetectionResults(foundPaths);
+                _ = SettingsManager.SaveAsync(settings);
             }
         }
         catch (OperationCanceledException)
@@ -73,6 +164,124 @@ public class GameLauncherService
         {
             IsDetecting = false;
             onComplete?.Invoke();
+        }
+    }
+
+    /// <summary>
+    /// Checks the two well-known default D2R install locations.
+    /// </summary>
+    private static (string? BattleNetPath, string? SteamPath) CheckDefaultPaths(CancellationToken token)
+    {
+        string? bnet = null;
+        string? steam = null;
+
+        foreach (var path in DefaultInstallPaths)
+        {
+            if (token.IsCancellationRequested) break;
+            if (!File.Exists(path)) continue;
+
+            var dir = Path.GetDirectoryName(path);
+            if (path.Contains("steamapps\\common", StringComparison.OrdinalIgnoreCase))
+                steam = dir;
+            else
+                bnet = dir;
+        }
+
+        return (bnet, steam);
+    }
+
+    /// <summary>
+    /// Ensures both B.Net and Steam profiles are populated from default paths when possible.
+    /// Called when the current profile is already valid, to discover the other installation.
+    /// </summary>
+    private void PopulateDefaultPaths(AppSettings settings)
+    {
+        foreach (var path in DefaultInstallPaths)
+        {
+            if (!File.Exists(path)) continue;
+            var dir = InstallDirectoryValidator.NormalizeInstallDirectory(Path.GetDirectoryName(path));
+            var type = DetectInstallationType(dir!);
+            var profile = GetProfileByType(settings, type);
+            if (profile.IsInstallDirectoryValidated) continue;
+
+            profile.InstallDirectory = dir;
+            profile.IsInstallDirectoryValidated = true;
+            if (type == InstallationType.Steam)
+                profile.SteamDirectory = FindSteamExecutable(profile.InstallDirectory);
+        }
+    }
+
+    private static InstallationProfile GetProfileByType(AppSettings settings, InstallationType type)
+    {
+        // Ensure profiles exist
+        _ = settings.CurrentProfile;
+        foreach (var p in settings.Profiles)
+        {
+            if (p.Type == type) return p;
+        }
+        // Should not happen with default 3 profiles, but just in case
+        var newProfile = new InstallationProfile { Type = type };
+        settings.Profiles.Add(newProfile);
+        return newProfile;
+    }
+
+    private static void NotifyDetectionResults((string? BattleNetPath, string? SteamPath) found)
+    {
+        if (found.BattleNetPath is not null && found.SteamPath is not null)
+        {
+            Notifications.SendNotification(
+                "Dual installation detected",
+                "Both Battle.Net and Steam installations of D2R were found. Use the dropdown to switch between them.");
+        }
+        else if (found.BattleNetPath is not null)
+        {
+            Notifications.SendNotification("Battle.Net installation detected", "D2R found in the default Battle.Net location.");
+        }
+        else if (found.SteamPath is not null)
+        {
+            Notifications.SendNotification("Steam installation detected", "D2R found in the default Steam location.");
+        }
+    }
+
+    public InstallationType DetectInstallationType(string path)
+    {
+        if (path.Contains("steamapps\\common", StringComparison.OrdinalIgnoreCase))
+        {
+            return InstallationType.Steam;
+        }
+        return InstallationType.BattleNet;
+    }
+
+    public string? FindSteamExecutable(string? d2rDir = null)
+    {
+        var targetD2rDir = d2rDir ?? MainWindow.Settings.InstallDirectory;
+        if (!string.IsNullOrEmpty(targetD2rDir) && targetD2rDir.Contains("steamapps\\common", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                var steamDir = Path.GetFullPath(Path.Combine(targetD2rDir, "..", "..", ".."));
+                var steamExe = Path.Combine(steamDir, "Steam.exe");
+                if (File.Exists(steamExe)) return steamExe;
+            }
+            catch { /* ignore path errors */ }
+        }
+
+        var defaultPath = @"C:\Program Files (x86)\Steam\steam.exe";
+        if (File.Exists(defaultPath)) return defaultPath;
+
+        return null;
+    }
+
+    private void CopyDirectory(string sourceDir, string targetDir)
+    {
+        Directory.CreateDirectory(targetDir);
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            File.Copy(file, Path.Combine(targetDir, Path.GetFileName(file)), true);
+        }
+        foreach (var directory in Directory.GetDirectories(sourceDir))
+        {
+            CopyDirectory(directory, Path.Combine(targetDir, Path.GetFileName(directory)));
         }
     }
 
@@ -206,33 +415,70 @@ public class GameLauncherService
 
     public string BuildLaunchCommand(string? launchParamOverride = null, string? gamePathOverride = null)
     {
+        var profile = MainWindow.Settings.CurrentProfile;
+        if (profile.Type == InstallationType.D2RMM)
+        {
+            return "D2RMM Install: No launch command. Clicking install mod will install reimagined.mpq into D2RMM/mods.";
+        }
+
         var launchParameters = string.IsNullOrWhiteSpace(launchParamOverride)
             ? LaunchParameters
             : launchParamOverride;
-        var executablePath = ResolveExecutablePath(gamePathOverride) ?? "D2R.exe";
 
+        if (profile.Type == InstallationType.Steam)
+        {
+            var steamPath = profile.SteamDirectory ?? @"C:\Program Files (x86)\Steam\steam.exe";
+            return $"\"{steamPath}\" -silent -applaunch 2536520 {launchParameters}";
+        }
+
+        var executablePath = ResolveExecutablePath(gamePathOverride) ?? "D2R.exe";
         return $"\"{executablePath}\" {launchParameters}";
     }
 
     public void LaunchGame(string? launchParamOverride = null, string? gamePathOverride = null)
     {
+        var profile = MainWindow.Settings.CurrentProfile;
+        
+        // D2RMM handled separately in LaunchView
+        if (profile.Type == InstallationType.D2RMM) return;
+
         if (!string.IsNullOrWhiteSpace(gamePathOverride))
         {
             GamePathOverride = gamePathOverride;
         }
 
-        var executablePath = ResolveExecutablePath(GamePathOverride);
-        LaunchDiagnostics.Log($"Resolved executable path: {executablePath ?? "<null>"}");
-        if (string.IsNullOrWhiteSpace(executablePath))
-        {
-            Notifications.SendNotification("No valid game path found. Please set the game path in settings.");
-            return;
-        }
-
         var launchParameters = string.IsNullOrWhiteSpace(launchParamOverride)
             ? LaunchParameters
             : launchParamOverride;
-        LaunchDiagnostics.Log($"Launch parameters: {launchParameters}");
+
+        string executablePath;
+        string finalArgs;
+
+        if (profile.Type == InstallationType.Steam)
+        {
+            executablePath = profile.SteamDirectory ?? @"C:\Program Files (x86)\Steam\steam.exe";
+            finalArgs = $"-silent -applaunch 2536520 {launchParameters}";
+            
+            if (!File.Exists(executablePath))
+            {
+                Notifications.SendNotification($"Steam.exe not found at {executablePath}. Please locate it in the Install Directory section.");
+                return;
+            }
+        }
+        else
+        {
+            executablePath = ResolveExecutablePath(GamePathOverride) ?? string.Empty;
+            finalArgs = launchParameters;
+            
+            if (string.IsNullOrWhiteSpace(executablePath))
+            {
+                Notifications.SendNotification("No valid game path found. Please set the game path in settings.");
+                return;
+            }
+        }
+
+        LaunchDiagnostics.Log($"Resolved executable path: {executablePath}");
+        LaunchDiagnostics.Log($"Launch parameters: {finalArgs}");
             
         if (!OperatingSystem.IsWindows())
         {
@@ -243,7 +489,7 @@ public class GameLauncherService
         var processStartInfo = new ProcessStartInfo(executablePath)
         {
             UseShellExecute = true,
-            Arguments = launchParameters
+            Arguments = finalArgs
         };
 
         try
@@ -252,7 +498,7 @@ public class GameLauncherService
             if (process == null)
             {
                 LaunchDiagnostics.Log("Process.Start returned null.");
-                Notifications.SendNotification("Failed to start D2R.exe.", "Warning");
+                Notifications.SendNotification($"Failed to start {Path.GetFileName(executablePath)}.", "Warning");
                 return;
             }
 
@@ -261,7 +507,7 @@ public class GameLauncherService
         catch (Win32Exception ex)
         {
             LaunchDiagnostics.LogException("Process.Start failed", ex);
-            Notifications.SendNotification($"Failed to start D2R.exe: {ex.Message}", "Warning");
+            Notifications.SendNotification($"Failed to start {Path.GetFileName(executablePath)}: {ex.Message}", "Warning");
         }
     }
 

--- a/ReimaginedLauncher/Utilities/GameLauncherService.cs
+++ b/ReimaginedLauncher/Utilities/GameLauncherService.cs
@@ -10,7 +10,11 @@ namespace ReimaginedLauncher.Utilities;
 
 public class GameLauncherService
 {
-    private const string? DefaultInstallPath = @"C:\Program Files (x86)\Diablo II Resurrected\D2R.exe";
+    private static readonly string[] DefaultInstallPaths =
+    [
+        @"C:\Program Files (x86)\Diablo II Resurrected\D2R.exe",
+        @"C:\Program Files (x86)\Steam\steamapps\common\Diablo II Resurrected\D2R.exe"
+    ];
     private CancellationTokenSource? _detectionCts;
     public bool IsDetecting { get; private set; }
     public string? GamePathOverride { get; set; } = string.Empty;
@@ -80,10 +84,13 @@ public class GameLauncherService
 
     private string? FindD2RExecutable(CancellationToken token)
     {
-        // Check the default installation path first
-        if (File.Exists(DefaultInstallPath))
+        // Check the default installation paths first
+        foreach (var path in DefaultInstallPaths)
         {
-            return DefaultInstallPath;
+            if (File.Exists(path))
+            {
+                return path;
+            }
         }
 
         // Iterate through all fixed drives

--- a/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
+++ b/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 
 namespace ReimaginedLauncher.Utilities;
 
@@ -32,6 +33,15 @@ public static class InstallDirectoryValidator
             return false;
 
         return File.Exists(Path.Combine(normalizedDirectory, ExecutableName));
+    }
+
+    public static bool IsValidSteamInstallDirectory(string? installDirectory)
+    {
+        if (!IsValidInstallDirectory(installDirectory))
+            return false;
+
+        var normalizedDirectory = NormalizeInstallDirectory(installDirectory)!;
+        return Directory.EnumerateFiles(normalizedDirectory, "steam_*.dll").Any();
     }
 
     public static string? GetExecutablePath(string? installDirectory)

--- a/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
+++ b/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
@@ -44,6 +44,23 @@ public static class InstallDirectoryValidator
         return Directory.EnumerateFiles(normalizedDirectory, "steam_*.dll").Any();
     }
 
+    public static bool IsValidD2RmmModsDirectory(string? modsDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(modsDirectory))
+            return false;
+
+        var dirName = Path.GetFileName(modsDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (!string.Equals(dirName, "mods", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var parentDir = Path.GetDirectoryName(modsDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        if (string.IsNullOrEmpty(parentDir))
+            return false;
+
+        var parentName = Path.GetFileName(parentDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        return string.Equals(parentName, "D2RMM", StringComparison.OrdinalIgnoreCase);
+    }
+
     public static string? GetExecutablePath(string? installDirectory)
     {
         var normalizedDirectory = NormalizeInstallDirectory(installDirectory);

--- a/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
+++ b/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
@@ -12,9 +12,17 @@ public static class InstallDirectoryValidator
         if (string.IsNullOrWhiteSpace(installDirectory))
             return null;
 
-        return installDirectory.EndsWith(ExecutableName, StringComparison.OrdinalIgnoreCase)
+        var directory = installDirectory.EndsWith(ExecutableName, StringComparison.OrdinalIgnoreCase)
             ? Path.GetDirectoryName(installDirectory)
             : installDirectory;
+
+        if (string.IsNullOrEmpty(directory))
+            return directory;
+
+        if (!directory.EndsWith(Path.DirectorySeparatorChar) && !directory.EndsWith(Path.AltDirectorySeparatorChar))
+            directory += Path.DirectorySeparatorChar;
+
+        return directory;
     }
 
     public static bool IsValidInstallDirectory(string? installDirectory)

--- a/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
+++ b/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
@@ -57,8 +57,25 @@ public static class InstallDirectoryValidator
         if (string.IsNullOrEmpty(parentDir))
             return false;
 
-        var parentName = Path.GetFileName(parentDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        return string.Equals(parentName, "D2RMM", StringComparison.OrdinalIgnoreCase);
+        return File.Exists(Path.Combine(parentDir, "D2RMM.exe"));
+    }
+
+    public static string GetD2RmmValidationMessage(string? modsDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(modsDirectory))
+            return "Invalid location. Please select the mods folder inside the D2RMM directory.";
+
+        var trimmed = modsDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var dirName = Path.GetFileName(trimmed);
+
+        if (!string.Equals(dirName, "mods", StringComparison.OrdinalIgnoreCase))
+            return "Invalid location. Please select the mods folder inside the D2RMM directory.";
+
+        var parentDir = Path.GetDirectoryName(trimmed);
+        if (string.IsNullOrEmpty(parentDir))
+            return "Invalid location. Please select the mods folder inside the D2RMM directory.";
+
+        return $"Invalid location. D2RMM.exe not found in the {parentDir} directory.";
     }
 
     public static string? GetExecutablePath(string? installDirectory)

--- a/ReimaginedLauncher/Utilities/ModTweaksService.cs
+++ b/ReimaginedLauncher/Utilities/ModTweaksService.cs
@@ -102,19 +102,32 @@ public static class ModTweaksService
         }
     }
 
-    private static string? GetExcelDirectory()
+    private static string? GetMpqBaseDirectory()
     {
-        var installDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(MainWindow.Settings.InstallDirectory);
+        var profile = MainWindow.Settings.CurrentProfile;
+        var installDirectory = profile.Type == InstallationType.D2RMM
+            ? profile.InstallDirectory
+            : InstallDirectoryValidator.NormalizeInstallDirectory(profile.InstallDirectory);
         if (string.IsNullOrWhiteSpace(installDirectory))
         {
             return null;
         }
 
+        return profile.Type == InstallationType.D2RMM
+            ? Path.Combine(installDirectory, $"{ModDirectoryName}.mpq")
+            : Path.Combine(installDirectory, "mods", ModDirectoryName, $"{ModDirectoryName}.mpq");
+    }
+
+    private static string? GetExcelDirectory()
+    {
+        var mpqBase = GetMpqBaseDirectory();
+        if (string.IsNullOrWhiteSpace(mpqBase))
+        {
+            return null;
+        }
+
         return Path.Combine(
-            installDirectory,
-            "mods",
-            ModDirectoryName,
-            $"{ModDirectoryName}.mpq",
+            mpqBase,
             DataDirectoryName,
             "global",
             ExcelDirectoryName);
@@ -122,17 +135,14 @@ public static class ModTweaksService
 
     private static string? GetMissilesFilePath()
     {
-        var installDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(MainWindow.Settings.InstallDirectory);
-        if (string.IsNullOrWhiteSpace(installDirectory))
+        var mpqBase = GetMpqBaseDirectory();
+        if (string.IsNullOrWhiteSpace(mpqBase))
         {
             return null;
         }
 
         return Path.Combine(
-            installDirectory,
-            "mods",
-            ModDirectoryName,
-            $"{ModDirectoryName}.mpq",
+            mpqBase,
             DataDirectoryName,
             HdDirectoryName,
             MissilesDirectoryName,
@@ -141,17 +151,14 @@ public static class ModTweaksService
 
     private static string? GetLayoutsProfileHdFilePath()
     {
-        var installDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(MainWindow.Settings.InstallDirectory);
-        if (string.IsNullOrWhiteSpace(installDirectory))
+        var mpqBase = GetMpqBaseDirectory();
+        if (string.IsNullOrWhiteSpace(mpqBase))
         {
             return null;
         }
 
         return Path.Combine(
-            installDirectory,
-            "mods",
-            ModDirectoryName,
-            $"{ModDirectoryName}.mpq",
+            mpqBase,
             DataDirectoryName,
             GlobalDirectoryName,
             UiDirectoryName,

--- a/ReimaginedLauncher/Utilities/SettingsManager.cs
+++ b/ReimaginedLauncher/Utilities/SettingsManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -20,7 +21,48 @@ public static class SettingsManager
             return new AppSettings();
 
         var json = await File.ReadAllTextAsync(SettingsFilePath);
-        return JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+        var settings = JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+
+        // Migration for old settings format
+        if (settings.Profiles.Count == 0)
+        {
+            // Trigger default profile creation
+            _ = settings.CurrentProfile;
+            
+            // Populate the first profile (BattleNet) with old settings if they exist
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var profile = settings.Profiles[0];
+
+            if (root.TryGetProperty("InstallDirectory", out var prop)) profile.InstallDirectory = prop.GetString();
+            if (root.TryGetProperty("IsInstallDirectoryValidated", out prop)) profile.IsInstallDirectoryValidated = prop.GetBoolean();
+            if (root.TryGetProperty("BackupSaveDirectory", out prop)) profile.BackupSaveDirectory = prop.GetString();
+            if (root.TryGetProperty("AutomaticBackupsEnabled", out prop)) profile.AutomaticBackupsEnabled = prop.GetBoolean();
+            if (root.TryGetProperty("BackupIntervalMinutes", out prop)) profile.BackupIntervalMinutes = prop.GetInt32();
+            if (root.TryGetProperty("BackupAmount", out prop)) profile.BackupAmount = prop.GetInt32();
+            if (root.TryGetProperty("NoSound", out prop)) profile.NoSound = prop.GetBoolean();
+            if (root.TryGetProperty("NoRumble", out prop)) profile.NoRumble = prop.GetBoolean();
+            if (root.TryGetProperty("ForceDesktop", out prop)) profile.ForceDesktop = prop.GetBoolean();
+            if (root.TryGetProperty("ResetOfflineMaps", out prop)) profile.ResetOfflineMaps = prop.GetBoolean();
+            if (root.TryGetProperty("EnableRespec", out prop)) profile.EnableRespec = prop.GetBoolean();
+            if (root.TryGetProperty("PlayersCount", out prop)) profile.PlayersCount = prop.ValueKind == JsonValueKind.Number ? prop.GetInt32() : null;
+            if (root.TryGetProperty("SkillPointsPerLevel", out prop)) profile.SkillPointsPerLevel = prop.GetInt32();
+            if (root.TryGetProperty("AttributesPerLevel", out prop)) profile.AttributesPerLevel = prop.GetInt32();
+            if (root.TryGetProperty("MaxSkillLevel", out prop)) profile.MaxSkillLevel = prop.GetInt32();
+            if (root.TryGetProperty("NormalResistPenalty", out prop)) profile.NormalResistPenalty = prop.GetInt32();
+            if (root.TryGetProperty("NightmareResistPenalty", out prop)) profile.NightmareResistPenalty = prop.GetInt32();
+            if (root.TryGetProperty("HellResistPenalty", out prop)) profile.HellResistPenalty = prop.GetInt32();
+            if (root.TryGetProperty("RemovePaladinAuraSound", out prop)) profile.RemovePaladinAuraSound = prop.GetBoolean();
+            if (root.TryGetProperty("RemoveSplashVfx", out prop)) profile.RemoveSplashVfx = prop.GetBoolean();
+            if (root.TryGetProperty("MakeTooltipBackgroundOpaque", out prop)) profile.MakeTooltipBackgroundOpaque = prop.GetBoolean();
+            
+            if (root.TryGetProperty("Plugins", out prop) && prop.ValueKind == JsonValueKind.Array)
+            {
+                profile.Plugins = JsonSerializer.Deserialize<List<PluginRegistration>>(prop.GetRawText()) ?? [];
+            }
+        }
+
+        return settings;
     }
 
     public static async Task SaveAsync(AppSettings settings)

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml
@@ -22,8 +22,10 @@
                 <StackPanel Spacing="12">
                     <TextBlock Classes="section-title"
                                Text="Launch" />
-                    <TextBlock Classes="muted"
-                               Text="The button stays available here and will enable once the install directory is valid and the mod is detected." />
+                    <TextBlock x:Name="StartGameDescription"
+                               Classes="muted"
+                               Text="The button stays available here and will enable once the install directory is valid and the mod is detected."
+                               TextWrapping="Wrap" />
                     <Button x:Name="StartGameButton"
                             Classes="accent"
                             Content="Start Game"
@@ -40,12 +42,12 @@
             <Border Grid.Row="2"
                     Classes="panel"
                     Padding="20">
-                <Grid RowDefinitions="Auto,Auto,Auto"
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto"
                       RowSpacing="14">
                     <StackPanel Spacing="4">
-                        <TextBlock Classes="section-title"
+                        <TextBlock x:Name="InstallDirectoryTitle" Classes="section-title"
                                    Text="Install Directory" />
-                        <TextBlock Classes="muted"
+                        <TextBlock x:Name="InstallDirectoryDescription" Classes="muted"
                                    Text="Select the Diablo II: Resurrected folder that contains your local mod installation (Folder with .exe in it)" />
                     </StackPanel>
 
@@ -59,14 +61,24 @@
                                    TextWrapping="Wrap" />
                     </Border>
 
-                    <Grid Grid.Row="2"
+                    <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="10">
+                        <TextBlock Text="Installation Type:" VerticalAlignment="Center" Classes="muted"/>
+                        <ComboBox x:Name="InstallationTypeComboBox" Width="200" SelectionChanged="OnInstallationTypeChanged">
+                            <ComboBoxItem Content="Battle.Net" />
+                            <ComboBoxItem Content="Steam" />
+                            <ComboBoxItem Content="D2RMM Launcher" />
+                        </ComboBox>
+                    </StackPanel>
+
+                    <Grid Grid.Row="3"
                           ColumnDefinitions="*,Auto"
                           ColumnSpacing="10">
                         <StackPanel Orientation="Horizontal"
                                     Spacing="10">
                             <TextBox x:Name="DirectoryTextBox"
                                      IsReadOnly="True"
-                                     Width="450" />
+                                     Width="563"
+                                     HorizontalAlignment="Left" />
                             <StackPanel x:Name="DetectionLoadingIndicator"
                                         Orientation="Horizontal"
                                         Spacing="8"
@@ -83,6 +95,19 @@
                         <Button Grid.Column="1"
                                 Content="Browse"
                                 Click="OnInstallDirectoryClick"
+                                VerticalContentAlignment="Center" />
+                    </Grid>
+
+                    <Grid x:Name="SteamExtraPanel" Grid.Row="4" ColumnDefinitions="*,Auto" ColumnSpacing="10" IsVisible="False">
+                        <TextBox x:Name="SteamPathTextBox"
+                                 IsReadOnly="True"
+                                 Width="563"
+                                 HorizontalAlignment="Left"
+                                 PlaceholderText="Steam.exe Path" />
+                        <Button x:Name="LocateSteamButton"
+                                Grid.Column="1"
+                                Content="Locate Steam.exe"
+                                Click="OnLocateSteamClick"
                                 VerticalContentAlignment="Center" />
                     </Grid>
                 </Grid>

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -111,7 +111,7 @@ public partial class LaunchView : UserControl
             InstallDirectoryTitle.Text = "D2RMM Mods Folder";
             InstallDirectoryDescription.Text = "Select your D2RMM mods folder where Reimagined.mpq will be installed.";
             
-            isValidated = !string.IsNullOrWhiteSpace(profile.InstallDirectory) && Directory.Exists(profile.InstallDirectory);
+            isValidated = InstallDirectoryValidator.IsValidD2RmmModsDirectory(profile.InstallDirectory) && Directory.Exists(profile.InstallDirectory);
             
             // For D2RMM, check if Reimagined.mpq exists in the mods folder
             isModDetected = isValidated && Directory.Exists(Path.Combine(profile.InstallDirectory!, "Reimagined.mpq"));
@@ -152,9 +152,11 @@ public partial class LaunchView : UserControl
         {
             ValidationBannerText.Text = string.IsNullOrWhiteSpace(profile.InstallDirectory)
                 ? "Select your D2RMM mods folder."
-                : !isModDetected && isValidated
-                    ? "Reimagined.mpq not yet installed in this mods folder."
-                    : "The selected folder could not be found.";
+                : !InstallDirectoryValidator.IsValidD2RmmModsDirectory(profile.InstallDirectory)
+                    ? "Invalid location. Please select the D2RMM/mods folder."
+                    : !isModDetected && isValidated
+                        ? "Reimagined.mpq not yet installed in this mods folder."
+                        : "The selected folder could not be found.";
         }
         else
         {
@@ -369,7 +371,7 @@ public partial class LaunchView : UserControl
             }
 
             profile.IsInstallDirectoryValidated = profile.Type == InstallationType.D2RMM
-                ? !string.IsNullOrWhiteSpace(profile.InstallDirectory)
+                ? InstallDirectoryValidator.IsValidD2RmmModsDirectory(profile.InstallDirectory)
                 : profile.Type == InstallationType.Steam
                     ? InstallDirectoryValidator.IsValidSteamInstallDirectory(profile.InstallDirectory)
                     : InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory);
@@ -408,8 +410,15 @@ public partial class LaunchView : UserControl
                 if (profile.Type == InstallationType.D2RMM)
                 {
                     Notifications.SendNotification(
-                        "D2RMM mods folder not found",
-                        "Select your D2RMM mods folder.");
+                        "Invalid D2RMM location",
+                        "Please select the D2RMM/mods folder.");
+                }
+                else if (profile.Type == InstallationType.Steam
+                         && InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory))
+                {
+                    Notifications.SendNotification(
+                        "Invalid Steam path",
+                        "The selected directory does not contain steam_*.dll. Please select a valid Steam installation or switch to Battle.Net.");
                 }
                 else
                 {
@@ -431,15 +440,6 @@ public partial class LaunchView : UserControl
                     await mainWindow.PromptInstallForMissingModAsync();
                 }
 
-                return;
-            }
-
-            if (profile.Type == InstallationType.Steam
-                && !InstallDirectoryValidator.IsValidSteamInstallDirectory(profile.InstallDirectory))
-            {
-                Notifications.SendNotification(
-                    "Invalid Steam path",
-                    "The selected directory does not contain steam_*.dll. Please select a valid Steam installation or switch to Battle.Net.");
                 return;
             }
 

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using System;
 using System.IO;
-using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -131,8 +130,8 @@ public partial class LaunchView : UserControl
 
         if (profile.Type == InstallationType.D2RMM)
         {
-            StartGameButton.Content = "Install Mod";
-            StartGameDescription.Text = "Clicking install mod will apply tweaks and adjustments to the files in your D2RMM/mods/Reimagined.mpq/data directory.";
+            StartGameButton.Content = "Install Tweaks";
+            StartGameDescription.Text = "Clicking 'Install Tweaks' will apply tweaks and adjustments to the files in your D2RMM/mods/Reimagined.mpq/data directory.";
             StartGameButton.IsEnabled = !_isLaunching && isValidated && isModDetected;
         }
         else
@@ -210,16 +209,6 @@ public partial class LaunchView : UserControl
             if (files.Count > 0)
             {
                 var selectedPath = files[0].Path.LocalPath;
-                var steamDir = Path.GetDirectoryName(selectedPath);
-
-                if (string.IsNullOrEmpty(steamDir) ||
-                    !Directory.EnumerateFiles(steamDir, "steam_*.dll").Any())
-                {
-                    Notifications.SendNotification(
-                        "Invalid Steam path",
-                        "The selected path does not contain steam_*.dll. Please select a valid Steam installation or switch to Battle.Net.");
-                    return;
-                }
 
                 MainWindow.Settings.CurrentProfile.SteamDirectory = selectedPath;
                 await SettingsManager.SaveAsync(MainWindow.Settings);

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -153,7 +153,7 @@ public partial class LaunchView : UserControl
             ValidationBannerText.Text = string.IsNullOrWhiteSpace(profile.InstallDirectory)
                 ? "Select your D2RMM mods folder."
                 : !InstallDirectoryValidator.IsValidD2RmmModsDirectory(profile.InstallDirectory)
-                    ? "Invalid location. Please select the D2RMM/mods folder."
+                    ? InstallDirectoryValidator.GetD2RmmValidationMessage(profile.InstallDirectory)
                     : !isModDetected && isValidated
                         ? "Reimagined.mpq not yet installed in this mods folder."
                         : "The selected folder could not be found.";
@@ -411,7 +411,7 @@ public partial class LaunchView : UserControl
                 {
                     Notifications.SendNotification(
                         "Invalid D2RMM location",
-                        "Please select the D2RMM/mods folder.");
+                        InstallDirectoryValidator.GetD2RmmValidationMessage(profile.InstallDirectory));
                 }
                 else if (profile.Type == InstallationType.Steam
                          && InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory))

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using System;
 using System.IO;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -120,7 +121,9 @@ public partial class LaunchView : UserControl
         {
             InstallDirectoryTitle.Text = "Install Directory";
             InstallDirectoryDescription.Text = "Select the Diablo II: Resurrected folder that contains your local mod installation (Folder with .exe in it)";
-            isValidated = InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory);
+            isValidated = profile.Type == InstallationType.Steam
+                ? InstallDirectoryValidator.IsValidSteamInstallDirectory(profile.InstallDirectory)
+                : InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory);
             isModDetected = MainWindow.IsLocalModDetected;
         }
 
@@ -159,7 +162,10 @@ public partial class LaunchView : UserControl
             ValidationBannerText.Text = !isValidated
                 ? string.IsNullOrWhiteSpace(profile.InstallDirectory)
                     ? "Enter your Diablo II: Resurrected install directory before using the launcher."
-                    : "The selected install directory has not been validated. Choose the folder that contains D2R.exe."
+                    : profile.Type == InstallationType.Steam
+                        && InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory)
+                        ? "The selected directory does not contain steam_*.dll. Please select a valid Steam installation or switch to Battle.Net."
+                        : "The selected install directory has not been validated. Choose the folder that contains D2R.exe."
                 : "D2R Reimagined mod not detected in this directory. Install the mod before launching.";
         }
         
@@ -203,7 +209,19 @@ public partial class LaunchView : UserControl
 
             if (files.Count > 0)
             {
-                MainWindow.Settings.CurrentProfile.SteamDirectory = files[0].Path.LocalPath;
+                var selectedPath = files[0].Path.LocalPath;
+                var steamDir = Path.GetDirectoryName(selectedPath);
+
+                if (string.IsNullOrEmpty(steamDir) ||
+                    !Directory.EnumerateFiles(steamDir, "steam_*.dll").Any())
+                {
+                    Notifications.SendNotification(
+                        "Invalid Steam path",
+                        "The selected path does not contain steam_*.dll. Please select a valid Steam installation or switch to Battle.Net.");
+                    return;
+                }
+
+                MainWindow.Settings.CurrentProfile.SteamDirectory = selectedPath;
                 await SettingsManager.SaveAsync(MainWindow.Settings);
                 RefreshInstallDirectoryState();
             }
@@ -363,7 +381,9 @@ public partial class LaunchView : UserControl
 
             profile.IsInstallDirectoryValidated = profile.Type == InstallationType.D2RMM
                 ? !string.IsNullOrWhiteSpace(profile.InstallDirectory)
-                : InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory);
+                : profile.Type == InstallationType.Steam
+                    ? InstallDirectoryValidator.IsValidSteamInstallDirectory(profile.InstallDirectory)
+                    : InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory);
 
             // Auto-detect type if it's currently BattleNet (default)
             if (profile.Type == InstallationType.BattleNet && profile.IsInstallDirectoryValidated)
@@ -422,6 +442,15 @@ public partial class LaunchView : UserControl
                     await mainWindow.PromptInstallForMissingModAsync();
                 }
 
+                return;
+            }
+
+            if (profile.Type == InstallationType.Steam
+                && !InstallDirectoryValidator.IsValidSteamInstallDirectory(profile.InstallDirectory))
+            {
+                Notifications.SendNotification(
+                    "Invalid Steam path",
+                    "The selected directory does not contain steam_*.dll. Please select a valid Steam installation or switch to Battle.Net.");
                 return;
             }
 

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using System;
+using System.IO;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -25,41 +26,190 @@ public partial class LaunchView : UserControl
     {
         base.OnAttachedToVisualTree(e);
 
-        if (MainWindow.Settings is not null && !MainWindow.Settings.IsInstallDirectoryValidated && !LauncherService.IsDetecting)
+        if (MainWindow.Settings is not null && !LauncherService.IsDetecting)
         {
-            _ = LauncherService.CheckForD2RExecutableAsync(async () =>
+            // Skip D2R.exe detection entirely when the active profile is D2RMM —
+            // it doesn't need a game executable.
+            var currentType = MainWindow.Settings.CurrentProfile.Type;
+            var needsDetection = false;
+
+            if (currentType != InstallationType.D2RMM)
             {
-                await Dispatcher.UIThread.InvokeAsync(async () =>
+                // Run detection if the current profile isn't validated, or if any
+                // non-D2RMM profile is still missing its install directory (dual-install check).
+                needsDetection = !MainWindow.Settings.IsInstallDirectoryValidated;
+                if (!needsDetection)
                 {
-                    RefreshInstallDirectoryState();
-                    if (TopLevel.GetTopLevel(this) is MainWindow mw)
+                    foreach (var p in MainWindow.Settings.Profiles)
                     {
-                        mw.RefreshLocalModState();
-                        await mw.RefreshUpdateStateAsync();
+                        if (p.Type != InstallationType.D2RMM && !p.IsInstallDirectoryValidated)
+                        {
+                            needsDetection = true;
+                            break;
+                        }
                     }
+                }
+            }
+
+            if (needsDetection)
+            {
+                _ = LauncherService.CheckForD2RExecutableAsync(async () =>
+                {
+                    await Dispatcher.UIThread.InvokeAsync(async () =>
+                    {
+                        RefreshInstallDirectoryState();
+                        if (TopLevel.GetTopLevel(this) is MainWindow mw)
+                        {
+                            mw.RefreshLocalModState();
+                            await mw.RefreshUpdateStateAsync();
+                        }
+                    });
                 });
-            });
+            }
+
             RefreshInstallDirectoryState();
         }
     }
 
     public void RefreshInstallDirectoryState()
     {
-        DirectoryTextBox.Text = MainWindow.Settings.InstallDirectory ?? string.Empty;
+        var settings = MainWindow.Settings;
+        var profile = settings.CurrentProfile;
+
+        InstallationTypeComboBox.SelectedIndex = (int)profile.Type;
+        DirectoryTextBox.Text = profile.InstallDirectory ?? string.Empty;
         DetectionLoadingIndicator.IsVisible = LauncherService.IsDetecting;
 
-        var isValidated = InstallDirectoryValidator.IsValidInstallDirectory(MainWindow.Settings.InstallDirectory);
-        var isModDetected = MainWindow.IsLocalModDetected;
-        MainWindow.Settings.IsInstallDirectoryValidated = isValidated;
-        StartGameButton.IsEnabled = !_isLaunching && isValidated && isModDetected;
+        SteamExtraPanel.IsVisible = profile.Type == InstallationType.Steam;
+        SteamPathTextBox.Text = profile.SteamDirectory ?? string.Empty;
+
+        // Auto-detect Steam path if not set or if it's currently Steam type
+        if (profile.Type == InstallationType.Steam)
+        {
+            var detectedSteam = LauncherService.FindSteamExecutable(profile.InstallDirectory);
+            if (!string.IsNullOrEmpty(detectedSteam) && File.Exists(detectedSteam))
+            {
+                if (profile.SteamDirectory != detectedSteam)
+                {
+                    profile.SteamDirectory = detectedSteam;
+                    SteamPathTextBox.Text = detectedSteam;
+                }
+                LocateSteamButton.IsEnabled = false;
+            }
+            else
+            {
+                LocateSteamButton.IsEnabled = true;
+            }
+        }
+
+
+        bool isValidated;
+        bool isModDetected;
+
+        if (profile.Type == InstallationType.D2RMM)
+        {
+            InstallDirectoryTitle.Text = "D2RMM Mods Folder";
+            InstallDirectoryDescription.Text = "Select your D2RMM mods folder where Reimagined.mpq will be installed.";
+            
+            isValidated = !string.IsNullOrWhiteSpace(profile.InstallDirectory) && Directory.Exists(profile.InstallDirectory);
+            
+            // For D2RMM, check if Reimagined.mpq exists in the mods folder
+            isModDetected = isValidated && Directory.Exists(Path.Combine(profile.InstallDirectory!, "Reimagined.mpq"));
+        }
+        else
+        {
+            InstallDirectoryTitle.Text = "Install Directory";
+            InstallDirectoryDescription.Text = "Select the Diablo II: Resurrected folder that contains your local mod installation (Folder with .exe in it)";
+            isValidated = InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory);
+            isModDetected = MainWindow.IsLocalModDetected;
+        }
+
+        profile.IsInstallDirectoryValidated = isValidated;
+
+        if (profile.Type == InstallationType.D2RMM)
+        {
+            StartGameButton.Content = "Install Mod";
+            StartGameDescription.Text = "Clicking install mod will apply tweaks and adjustments to the files in your D2RMM/mods/Reimagined.mpq/data directory.";
+            StartGameButton.IsEnabled = !_isLaunching && isValidated && isModDetected;
+        }
+        else
+        {
+            StartGameButton.Content = "Start Game";
+            StartGameDescription.Text = "The button stays available here and will enable once the install directory is valid and the mod is detected.";
+            StartGameButton.IsEnabled = !_isLaunching && isValidated && isModDetected;
+
+            if (profile.Type == InstallationType.Steam && string.IsNullOrWhiteSpace(profile.SteamDirectory))
+            {
+                StartGameButton.IsEnabled = false;
+            }
+        }
+
         ValidationBanner.IsVisible = !isValidated || !isModDetected;
-        ValidationBannerText.Text = !isValidated
-            ? string.IsNullOrWhiteSpace(MainWindow.Settings.InstallDirectory)
-                ? "Enter your Diablo II: Resurrected install directory before using the launcher."
-                : "The selected install directory has not been validated. Choose the folder that contains D2R.exe."
-            : "D2R Reimagined mod not detected in this directory. Install the mod before launching.";
+        
+        if (profile.Type == InstallationType.D2RMM)
+        {
+            ValidationBannerText.Text = string.IsNullOrWhiteSpace(profile.InstallDirectory)
+                ? "Select your D2RMM mods folder."
+                : !isModDetected && isValidated
+                    ? "Reimagined.mpq not yet installed in this mods folder."
+                    : "The selected folder could not be found.";
+        }
+        else
+        {
+            ValidationBannerText.Text = !isValidated
+                ? string.IsNullOrWhiteSpace(profile.InstallDirectory)
+                    ? "Enter your Diablo II: Resurrected install directory before using the launcher."
+                    : "The selected install directory has not been validated. Choose the folder that contains D2R.exe."
+                : "D2R Reimagined mod not detected in this directory. Install the mod before launching.";
+        }
+        
         LaunchCommandText.Text = LauncherService.BuildLaunchCommand();
     }
+
+    private async void OnInstallationTypeChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (InstallationTypeComboBox == null) return;
+        
+        var selectedIndex = InstallationTypeComboBox.SelectedIndex;
+        if (selectedIndex < 0) return;
+
+        var newType = (InstallationType)selectedIndex;
+        if (MainWindow.Settings.CurrentProfile.Type == newType) return;
+
+        // Switch profile
+        MainWindow.Settings.SelectedProfileIndex = selectedIndex;
+        BackupService.ApplyDefaultSettings();
+        await SettingsManager.SaveAsync(MainWindow.Settings);
+
+        if (TopLevel.GetTopLevel(this) is MainWindow mw)
+        {
+            mw.RefreshLocalModState();
+            await mw.RefreshUpdateStateAsync();
+        }
+        
+        RefreshInstallDirectoryState();
+    }
+
+    private async void OnLocateSteamClick(object? sender, RoutedEventArgs e)
+    {
+        if (TopLevel.GetTopLevel(this) is Window window)
+        {
+            var files = await window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Locate Steam.exe",
+                AllowMultiple = false,
+                FileTypeFilter = [new FilePickerFileType("Steam Executable") { Patterns = ["Steam.exe"] }]
+            });
+
+            if (files.Count > 0)
+            {
+                MainWindow.Settings.CurrentProfile.SteamDirectory = files[0].Path.LocalPath;
+                await SettingsManager.SaveAsync(MainWindow.Settings);
+                RefreshInstallDirectoryState();
+            }
+        }
+    }
+
 
     private void SetLaunchStatus(string status, bool isVisible = true)
     {
@@ -70,17 +220,19 @@ public partial class LaunchView : UserControl
     private async void OnRunClick(object? sender, RoutedEventArgs e)
     {
         LaunchDiagnostics.ResetSession();
-        LaunchDiagnostics.Log("Launch button clicked.");
+        LaunchDiagnostics.Log("Launch/Install button clicked.");
 
         if (_isLaunching)
         {
-            LaunchDiagnostics.Log("Launch ignored because a launch is already in progress.");
+            LaunchDiagnostics.Log("Action ignored because an action is already in progress.");
             return;
         }
 
-        if (!MainWindow.Settings.IsInstallDirectoryValidated)
+        var profile = MainWindow.Settings.CurrentProfile;
+
+        if (!profile.IsInstallDirectoryValidated)
         {
-            LaunchDiagnostics.Log("Launch blocked because install directory is not validated.");
+            LaunchDiagnostics.Log("Action blocked because install directory is not validated.");
             Notifications.SendNotification(
                 "Install directory not validated",
                 "Choose the Diablo II: Resurrected folder that contains D2R.exe.");
@@ -89,10 +241,10 @@ public partial class LaunchView : UserControl
 
         if (!MainWindow.IsLocalModDetected)
         {
-            LaunchDiagnostics.Log("Launch blocked because the local mod was not detected.");
+            LaunchDiagnostics.Log("Action blocked because the local mod was not detected.");
             Notifications.SendNotification(
                 "D2R Reimagined mod not detected",
-                "Install the mod in the selected directory before launching.");
+                "Install the mod in the selected directory before launching/installing.");
 
             if (TopLevel.GetTopLevel(this) is MainWindow mainWindow)
             {
@@ -102,9 +254,11 @@ public partial class LaunchView : UserControl
             return;
         }
 
+
         _isLaunching = true;
         StartGameButton.IsEnabled = false;
-        SetLaunchStatus("Preparing launch...");
+        var actionName = profile.Type == InstallationType.D2RMM ? "Installation" : "Launch";
+        SetLaunchStatus($"Preparing {actionName.ToLower()}...");
         var progress = new Progress<string>(status => SetLaunchStatus(status));
 
         try
@@ -114,44 +268,52 @@ public partial class LaunchView : UserControl
             if (!prepared)
             {
                 LaunchDiagnostics.Log("Mod tweak preparation returned false.");
-                SetLaunchStatus("Launch preparation failed.");
-                Notifications.SendNotification("Launch preparation failed. See previous warning for details.", "Warning");
+                SetLaunchStatus($"{actionName} preparation failed.");
+                Notifications.SendNotification($"{actionName} preparation failed. See previous warning for details.", "Warning");
                 return;
             }
 
-            if (MainWindow.Settings.AutomaticBackupsEnabled)
+            if (profile.AutomaticBackupsEnabled)
             {
-                LaunchDiagnostics.Log("Starting launch backup.");
-                SetLaunchStatus("Creating launch backup...");
+                LaunchDiagnostics.Log("Starting backup.");
+                SetLaunchStatus("Creating backup...");
                 var backupCreated = await Task.Run(BackupService.CreateLaunchBackupAsync);
                 if (!backupCreated)
                 {
-                    LaunchDiagnostics.Log("Launch backup returned false.");
-                    Notifications.SendNotification("Launch backup failed. Continuing with game launch.", "Warning");
+                    LaunchDiagnostics.Log("Backup returned false.");
+                    Notifications.SendNotification("Backup failed. Continuing.", "Warning");
                 }
             }
 
             try
             {
-                LaunchDiagnostics.Log("Calling GameLauncherService.LaunchGame.");
-                SetLaunchStatus("Starting Diablo II: Resurrected...");
-                LauncherService.LaunchGame();
-                LaunchDiagnostics.Log("GameLauncherService.LaunchGame returned without throwing.");
+                if (profile.Type == InstallationType.D2RMM)
+                {
+                    LaunchDiagnostics.Log("D2RMM: Tweaks applied. Installation complete.");
+                    SetLaunchStatus("D2RMM mod tweaks applied.");
+                }
+                else
+                {
+                    LaunchDiagnostics.Log("Calling GameLauncherService.LaunchGame.");
+                    SetLaunchStatus("Starting Diablo II: Resurrected...");
+                    LauncherService.LaunchGame();
+                    LaunchDiagnostics.Log("GameLauncherService.LaunchGame returned without throwing.");
+                    SetLaunchStatus($"{actionName} command sent.");
+                }
             }
             catch (Exception ex)
             {
-                LaunchDiagnostics.LogException("GameLauncherService.LaunchGame threw an exception", ex);
-                SetLaunchStatus("Game launch failed.");
-                Notifications.SendNotification($"Game launch failed: {ex.Message}", "Warning");
+                LaunchDiagnostics.LogException($"{actionName} failed", ex);
+                SetLaunchStatus($"{actionName} failed.");
+                Notifications.SendNotification($"{actionName} failed: {ex.Message}", "Warning");
                 return;
             }
 
-            SetLaunchStatus("Launch command sent.");
-            Notifications.SendNotification("Clicked Launch", "Success");
+            Notifications.SendNotification(profile.Type == InstallationType.D2RMM ? "Installed Mod to D2RMM" : "Launched Game", "Success");
         }
         finally
         {
-            LaunchDiagnostics.Log("Launch flow completed.");
+            LaunchDiagnostics.Log($"{actionName} flow completed.");
             _isLaunching = false;
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
@@ -170,18 +332,59 @@ public partial class LaunchView : UserControl
         LauncherService.CancelDetection();
         if (TopLevel.GetTopLevel(this) is Window window)
         {
-            var folders = await window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            var profile = MainWindow.Settings.CurrentProfile;
+            if (profile.Type == InstallationType.D2RMM)
             {
-                Title = "Select Install Folder",
-                AllowMultiple = false
-            });
+                var folders = await window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = "Select D2RMM mods folder",
+                    AllowMultiple = false
+                });
 
-            if (folders.Count <= 0) return;
+                if (folders.Count > 0)
+                {
+                    profile.InstallDirectory = folders[0].Path.LocalPath;
+                }
+                else return;
+            }
+            else
+            {
+                var folders = await window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+                {
+                    Title = "Select Install Folder",
+                    AllowMultiple = false
+                });
 
-            var path = folders[0].Path.LocalPath;
-            MainWindow.Settings.InstallDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(path);
-            MainWindow.Settings.IsInstallDirectoryValidated =
-                InstallDirectoryValidator.IsValidInstallDirectory(MainWindow.Settings.InstallDirectory);
+                if (folders.Count <= 0) return;
+
+                var path = folders[0].Path.LocalPath;
+                profile.InstallDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(path);
+            }
+
+            profile.IsInstallDirectoryValidated = profile.Type == InstallationType.D2RMM
+                ? !string.IsNullOrWhiteSpace(profile.InstallDirectory)
+                : InstallDirectoryValidator.IsValidInstallDirectory(profile.InstallDirectory);
+
+            // Auto-detect type if it's currently BattleNet (default)
+            if (profile.Type == InstallationType.BattleNet && profile.IsInstallDirectoryValidated)
+            {
+                var detectedType = LauncherService.DetectInstallationType(profile.InstallDirectory!);
+                if (detectedType != InstallationType.BattleNet)
+                {
+                    profile.Type = detectedType;
+                }
+            }
+
+            // Auto-detect Steam path if it's Steam
+            if (profile.Type == InstallationType.Steam)
+            {
+                var detectedSteam = LauncherService.FindSteamExecutable(profile.InstallDirectory);
+                if (!string.IsNullOrEmpty(detectedSteam))
+                {
+                    profile.SteamDirectory = detectedSteam;
+                }
+            }
+
             await SettingsManager.SaveAsync(MainWindow.Settings);
             BackupService.UpdateSchedule();
             if (TopLevel.GetTopLevel(this) is MainWindow mw)
@@ -191,15 +394,24 @@ public partial class LaunchView : UserControl
             }
             RefreshInstallDirectoryState();
 
-            if (!MainWindow.Settings.IsInstallDirectoryValidated)
+            if (!profile.IsInstallDirectoryValidated)
             {
-                Notifications.SendNotification(
-                    "D2R install not found",
-                    "Select the Diablo II: Resurrected folder that contains D2R.exe.");
+                if (profile.Type == InstallationType.D2RMM)
+                {
+                    Notifications.SendNotification(
+                        "D2RMM mods folder not found",
+                        "Select your D2RMM mods folder.");
+                }
+                else
+                {
+                    Notifications.SendNotification(
+                        "D2R install not found",
+                        "Select the Diablo II: Resurrected folder that contains D2R.exe.");
+                }
                 return;
             }
 
-            if (!MainWindow.IsLocalModDetected)
+            if (profile.Type != InstallationType.D2RMM && !MainWindow.IsLocalModDetected)
             {
                 Notifications.SendNotification(
                     "D2R Reimagined mod not detected",
@@ -213,7 +425,7 @@ public partial class LaunchView : UserControl
                 return;
             }
 
-            Notifications.SendNotification("Install directory validated", "Success");
+            Notifications.SendNotification(profile.Type == InstallationType.D2RMM ? "D2RMM mods folder selected" : "Install directory validated", "Success");
         }
     }
 }

--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml
@@ -19,69 +19,76 @@
                 <StackPanel Spacing="14">
                     <TextBlock Classes="section-title"
                                Text="Launch Parameters" />
-                    <StackPanel Spacing="4">
-                        <CheckBox x:Name="EnableRespecCheckBox"
-                                  Content="-enablerespec"
-                                  IsCheckedChanged="OnLaunchSettingChanged"/>
-                        <TextBlock Classes="muted"
-                                   Margin="28,0,0,0"
-                                   TextWrapping="Wrap"
-                                   Text="Enables unlimited stat and skill respecs in-game. Hold ALT and left-click any STR/DEX/VIT/ENERGY plus button to trigger a stat reset." />
-                    </StackPanel>
-                    <StackPanel Spacing="4">
-                        <CheckBox x:Name="ResetOfflineMapsCheckBox"
-                                  Content="-resetofflinemaps"
-                                  IsCheckedChanged="OnLaunchSettingChanged"/>
-                        <TextBlock Classes="muted"
-                                   Margin="28,0,0,0"
-                                   TextWrapping="Wrap"
-                                   Text="Generates fresh offline map layouts every time the game starts. If you only want to reset all maps once, you can also switch difficulties (Normal/Nightmare/Hell) on a single character." />
-                    </StackPanel>
-                    <StackPanel Spacing="8">
-                        <TextBlock Text="-players"
-                                   FontWeight="SemiBold" />
-                        <TextBlock Classes="muted"
-                                   TextWrapping="Wrap"
-                                   Text="Simulates higher player counts offline to increase difficulty and drops. The game sets /players to this value whenever you enter a game. You can change it in-game, but it resets to this value after returning to the character select screen." />
-                        <ComboBox x:Name="PlayersComboBox"
-                                  Width="180"
-                                  SelectionChanged="OnPlayersSelectionChanged">
-                            <ComboBoxItem Content="Disabled"/>
-                            <ComboBoxItem Content="2"/>
-                            <ComboBoxItem Content="3"/>
-                            <ComboBoxItem Content="4"/>
-                            <ComboBoxItem Content="5"/>
-                            <ComboBoxItem Content="6"/>
-                            <ComboBoxItem Content="7"/>
-                            <ComboBoxItem Content="8"/>
-                        </ComboBox>
-                    </StackPanel>
-                    <StackPanel Spacing="4">
-                        <CheckBox x:Name="NoRumbleCheckBox"
-                                  Content="-norumble"
-                                  IsCheckedChanged="OnLaunchSettingChanged"/>
-                        <TextBlock Classes="muted"
-                                   Margin="28,0,0,0"
-                                   TextWrapping="Wrap"
-                                   Text="Disables controller vibration." />
-                    </StackPanel>
-                    <StackPanel Spacing="4">
-                        <CheckBox x:Name="ForceDesktopCheckBox"
-                                  Content="-forcedesktop"
-                                  IsCheckedChanged="OnLaunchSettingChanged"/>
-                        <TextBlock Classes="muted"
-                                   Margin="28,0,0,0"
-                                   TextWrapping="Wrap"
-                                   Text="Forces the desktop mouse-and-keyboard UI on devices the game otherwise treats as handheld." />
-                    </StackPanel>
-                    <StackPanel Spacing="4">
-                        <CheckBox x:Name="NoSoundCheckBox"
-                                  Content="-nosound"
-                                  IsCheckedChanged="OnLaunchSettingChanged"/>
-                        <TextBlock Classes="muted"
-                                   Margin="28,0,0,0"
-                                   TextWrapping="Wrap"
-                                   Text="Starts the game without audio output." />
+                    <TextBlock x:Name="D2RmmLaunchParamsNotice"
+                               Classes="muted"
+                               IsVisible="False"
+                               TextWrapping="Wrap"
+                               Text="Launch parameters are not available when using the D2RMM launcher. Configure launch options directly in D2RMM." />
+                    <StackPanel x:Name="LaunchParametersPanel" Spacing="10">
+                        <StackPanel Spacing="4">
+                            <CheckBox x:Name="EnableRespecCheckBox"
+                                      Content="-enablerespec"
+                                      IsCheckedChanged="OnLaunchSettingChanged"/>
+                            <TextBlock Classes="muted"
+                                       Margin="28,0,0,0"
+                                       TextWrapping="Wrap"
+                                       Text="Enables unlimited stat and skill respecs in-game. Hold ALT and left-click any STR/DEX/VIT/ENERGY plus button to trigger a stat reset." />
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <CheckBox x:Name="ResetOfflineMapsCheckBox"
+                                      Content="-resetofflinemaps"
+                                      IsCheckedChanged="OnLaunchSettingChanged"/>
+                            <TextBlock Classes="muted"
+                                       Margin="28,0,0,0"
+                                       TextWrapping="Wrap"
+                                       Text="Generates fresh offline map layouts every time the game starts. If you only want to reset all maps once, you can also switch difficulties (Normal/Nightmare/Hell) on a single character." />
+                        </StackPanel>
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="-players"
+                                       FontWeight="SemiBold" />
+                            <TextBlock Classes="muted"
+                                       TextWrapping="Wrap"
+                                       Text="Simulates higher player counts offline to increase difficulty and drops. The game sets /players to this value whenever you enter a game. You can change it in-game, but it resets to this value after returning to the character select screen." />
+                            <ComboBox x:Name="PlayersComboBox"
+                                      Width="180"
+                                      SelectionChanged="OnPlayersSelectionChanged">
+                                <ComboBoxItem Content="Disabled"/>
+                                <ComboBoxItem Content="2"/>
+                                <ComboBoxItem Content="3"/>
+                                <ComboBoxItem Content="4"/>
+                                <ComboBoxItem Content="5"/>
+                                <ComboBoxItem Content="6"/>
+                                <ComboBoxItem Content="7"/>
+                                <ComboBoxItem Content="8"/>
+                            </ComboBox>
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <CheckBox x:Name="NoRumbleCheckBox"
+                                      Content="-norumble"
+                                      IsCheckedChanged="OnLaunchSettingChanged"/>
+                            <TextBlock Classes="muted"
+                                       Margin="28,0,0,0"
+                                       TextWrapping="Wrap"
+                                       Text="Disables controller vibration." />
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <CheckBox x:Name="ForceDesktopCheckBox"
+                                      Content="-forcedesktop"
+                                      IsCheckedChanged="OnLaunchSettingChanged"/>
+                            <TextBlock Classes="muted"
+                                       Margin="28,0,0,0"
+                                       TextWrapping="Wrap"
+                                       Text="Forces the desktop mouse-and-keyboard UI on devices the game otherwise treats as handheld." />
+                        </StackPanel>
+                        <StackPanel Spacing="4">
+                            <CheckBox x:Name="NoSoundCheckBox"
+                                      Content="-nosound"
+                                      IsCheckedChanged="OnLaunchSettingChanged"/>
+                            <TextBlock Classes="muted"
+                                       Margin="28,0,0,0"
+                                       TextWrapping="Wrap"
+                                       Text="Starts the game without audio output." />
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
@@ -23,14 +23,32 @@ public partial class SettingsView : UserControl
             <= 0.95 => 1,
             _ => 2
         };
-        NoSoundCheckBox.IsChecked = MainWindow.Settings.NoSound;
-        NoRumbleCheckBox.IsChecked = MainWindow.Settings.NoRumble;
-        ForceDesktopCheckBox.IsChecked = MainWindow.Settings.ForceDesktop;
-        ResetOfflineMapsCheckBox.IsChecked = MainWindow.Settings.ResetOfflineMaps;
-        EnableRespecCheckBox.IsChecked = MainWindow.Settings.EnableRespec;
-        PlayersComboBox.SelectedIndex = MainWindow.Settings.PlayersCount is >= 2 and <= 8
-            ? MainWindow.Settings.PlayersCount.Value - 1
-            : 0;
+
+        var isD2Rmm = MainWindow.Settings.CurrentProfile.Type == InstallationType.D2RMM;
+        LaunchParametersPanel.IsEnabled = !isD2Rmm;
+        D2RmmLaunchParamsNotice.IsVisible = isD2Rmm;
+
+        if (isD2Rmm)
+        {
+            NoSoundCheckBox.IsChecked = false;
+            NoRumbleCheckBox.IsChecked = false;
+            ForceDesktopCheckBox.IsChecked = false;
+            ResetOfflineMapsCheckBox.IsChecked = false;
+            EnableRespecCheckBox.IsChecked = false;
+            PlayersComboBox.SelectedIndex = 0;
+        }
+        else
+        {
+            NoSoundCheckBox.IsChecked = MainWindow.Settings.NoSound;
+            NoRumbleCheckBox.IsChecked = MainWindow.Settings.NoRumble;
+            ForceDesktopCheckBox.IsChecked = MainWindow.Settings.ForceDesktop;
+            ResetOfflineMapsCheckBox.IsChecked = MainWindow.Settings.ResetOfflineMaps;
+            EnableRespecCheckBox.IsChecked = MainWindow.Settings.EnableRespec;
+            PlayersComboBox.SelectedIndex = MainWindow.Settings.PlayersCount is >= 2 and <= 8
+                ? MainWindow.Settings.PlayersCount.Value - 1
+                : 0;
+        }
+
         _isRefreshingSettings = false;
     }
 

--- a/ReimaginedLauncher/Views/Update/UpdateView.axaml
+++ b/ReimaginedLauncher/Views/Update/UpdateView.axaml
@@ -6,7 +6,7 @@
              x:Class="ReimaginedLauncher.Views.Update.UpdateView">
     <StackPanel Spacing="16">
         <StackPanel Spacing="4">
-            <TextBlock Classes="view-title" Text="Update"/>
+            <TextBlock Classes="view-title" Text="Install/Update"/>
             <TextBlock Classes="muted" Text="Check the local install state and pull the newest Reimagined release."/>
         </StackPanel>
         <Border x:Name="LoadingBanner"
@@ -39,6 +39,21 @@
                 <TextBlock Grid.Row="1" Grid.Column="0" Text="Latest Version:" Margin="0,0,10,0"/>
                 <TextBlock x:Name="LatestVersionText" Grid.Row="1" Grid.Column="1" FontWeight="Bold"/>
             </Grid>
+        </Border>
+        <Border x:Name="InstallProgressBanner"
+                Classes="panel"
+                Padding="16"
+                IsVisible="False">
+            <StackPanel Spacing="10">
+                <TextBlock x:Name="InstallProgressTitle"
+                           Text="Installing..."
+                           FontWeight="SemiBold"/>
+                <ProgressBar IsIndeterminate="True"
+                             Height="8"/>
+                <TextBlock x:Name="InstallProgressMessage"
+                           Classes="muted"
+                           Text="Please wait while the mod is being installed."/>
+            </StackPanel>
         </Border>
         <Border x:Name="AuthWarningBanner"
                 Classes="warning-banner"

--- a/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
+++ b/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
@@ -326,14 +326,14 @@ public partial class UpdateView : UserControl
 
                     var targetMpqDir = Path.Combine(installDirectory, "Reimagined.mpq");
                     if (Directory.Exists(targetMpqDir))
-                    {
-                        var backupDir = Path.Combine(installDirectory, "Reimagined.mpq.backup");
-                        if (Directory.Exists(backupDir))
-                            Directory.Delete(backupDir, recursive: true);
-                        Directory.Move(targetMpqDir, backupDir);
-                    }
+                        Directory.Delete(targetMpqDir, recursive: true);
 
                     CopyDirectory(sourceMpqDir, targetMpqDir);
+
+                    var backupDir = Path.Combine(installDirectory, "Reimagined.mpq.backup");
+                    if (Directory.Exists(backupDir))
+                        Directory.Delete(backupDir, recursive: true);
+
                     return true;
                 }
                 finally

--- a/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
+++ b/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
@@ -31,10 +31,11 @@ public partial class UpdateView : UserControl
         var canDownload = isInstallMissing || MainWindow.IsUpdateAvailable;
 
         LoadingBanner.IsVisible = _isLoading;
-        StatusBorder.IsVisible = !_isLoading;
-        VersionsBorder.IsVisible = !_isLoading;
-        AuthWarningBanner.IsVisible = !_isLoading && !isAuthenticated;
-        NonPremiumWarningBanner.IsVisible = !_isLoading && usesDownloadsWatcher && canDownload;
+        InstallProgressBanner.IsVisible = _isInstalling;
+        StatusBorder.IsVisible = !_isLoading && !_isInstalling;
+        VersionsBorder.IsVisible = !_isLoading && !_isInstalling;
+        AuthWarningBanner.IsVisible = !_isLoading && !_isInstalling && !isAuthenticated;
+        NonPremiumWarningBanner.IsVisible = !_isLoading && !_isInstalling && usesDownloadsWatcher && canDownload;
 
         StatusTitleText.Text = MainWindow.UpdateStatusTitle;
         StatusMessageText.Text = MainWindow.UpdateStatusMessage;
@@ -47,7 +48,7 @@ public partial class UpdateView : UserControl
                                           canDownload;
         SelectZipManuallyButton.IsEnabled = !_isLoading &&
                                             !_isInstalling &&
-                                            MainWindow.Settings.IsInstallDirectoryValidated &&
+                                            MainWindow.Settings.CurrentProfile.IsInstallDirectoryValidated &&
                                             !string.IsNullOrWhiteSpace(MainWindow.Settings.InstallDirectory);
         OpenDownloadPageButton.IsEnabled = !_isLoading && !string.IsNullOrWhiteSpace(MainWindow.UpdateDownloadUrl);
         RecheckButton.IsEnabled = !_isLoading;
@@ -75,12 +76,15 @@ public partial class UpdateView : UserControl
             return;
         }
         
-        var installDirectory = MainWindow.Settings.InstallDirectory;
-        if (!MainWindow.Settings.IsInstallDirectoryValidated || string.IsNullOrWhiteSpace(installDirectory))
+        var profile = MainWindow.Settings.CurrentProfile;
+        var installDirectory = profile.InstallDirectory;
+        if (!profile.IsInstallDirectoryValidated || string.IsNullOrWhiteSpace(installDirectory))
         {
             Notifications.SendNotification(
                 "Install directory not validated",
-                "Select the Diablo II: Resurrected folder before installing the mod.");
+                profile.Type == InstallationType.D2RMM
+                    ? "Select the D2RMM mods folder before installing the mod."
+                    : "Select the Diablo II: Resurrected folder before installing the mod.");
             return;
         }
 
@@ -92,6 +96,7 @@ public partial class UpdateView : UserControl
             if (MainWindow.Settings.NexusPremiumDownloadAccess == false)
             {
                 Notifications.SendNotification("Open Manual Download in browser. Waiting for zip in Downloads...", "Info");
+                SetInstallProgress("Waiting for download...", "Complete the manual download in your browser. The launcher is watching your Downloads folder.");
                 OnOpenDownloadPageClick(null, null);
                 var downloadedZip = await WaitForNewZipFromDownloadsAsync(TimeSpan.FromMinutes(8));
                 if (string.IsNullOrWhiteSpace(downloadedZip))
@@ -100,11 +105,12 @@ public partial class UpdateView : UserControl
                     return;
                 }
 
+                SetInstallProgress("Installing...", "Download detected. Extracting and installing mod files.");
                 await ExtractAndFinalizeInstallAsync(downloadedZip, installDirectory);
                 return;
             }
 
-            Notifications.SendNotification("Downloading mod archive. This may take a moment.");
+            SetInstallProgress("Downloading...", "Downloading mod archive from Nexus Mods. This may take a moment.");
             await DownloadExtractAndFinalizeInstallAsync(MainWindow.UpdateDownloadUrl, installDirectory);
         }
         catch (Exception ex)
@@ -144,12 +150,15 @@ public partial class UpdateView : UserControl
         if (_isInstalling)
             return;
 
-        var installDirectory = MainWindow.Settings.InstallDirectory;
-        if (!MainWindow.Settings.IsInstallDirectoryValidated || string.IsNullOrWhiteSpace(installDirectory))
+        var profile = MainWindow.Settings.CurrentProfile;
+        var installDirectory = profile.InstallDirectory;
+        if (!profile.IsInstallDirectoryValidated || string.IsNullOrWhiteSpace(installDirectory))
         {
             Notifications.SendNotification(
                 "Install directory not validated",
-                "Select the Diablo II: Resurrected folder before installing the mod.");
+                profile.Type == InstallationType.D2RMM
+                    ? "Select the D2RMM mods folder before installing the mod."
+                    : "Select the Diablo II: Resurrected folder before installing the mod.");
             return;
         }
 
@@ -187,6 +196,7 @@ public partial class UpdateView : UserControl
         {
             _isInstalling = true;
             RefreshUpdateState();
+            SetInstallProgress("Installing...", "Extracting and installing mod files from selected zip.");
             await ExtractAndFinalizeInstallAsync(zipPath, installDirectory);
         }
         catch (Exception ex)
@@ -240,6 +250,7 @@ public partial class UpdateView : UserControl
 
         try
         {
+            SetInstallProgress("Downloading...", "Downloading mod archive. Please wait.");
             using var httpClient = new HttpClient();
             using var response = await httpClient.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead);
             response.EnsureSuccessStatusCode();
@@ -259,6 +270,7 @@ public partial class UpdateView : UserControl
                 return;
             }
 
+            SetInstallProgress("Installing...", "Extracting and installing mod files.");
             await ExtractAndFinalizeInstallAsync(tempZipPath, installDirectory);
         }
         finally
@@ -270,6 +282,13 @@ public partial class UpdateView : UserControl
         }
     }
 
+    private void SetInstallProgress(string title, string message)
+    {
+        InstallProgressTitle.Text = title;
+        InstallProgressMessage.Text = message;
+        InstallProgressBanner.IsVisible = true;
+    }
+
     private async Task ExtractAndFinalizeInstallAsync(string zipPath, string installDirectory)
     {
         if (!IsZipArchive(zipPath))
@@ -278,19 +297,82 @@ public partial class UpdateView : UserControl
             return;
         }
 
-        var modDir = Path.Combine(installDirectory, "mods", "Reimagined");
-        if (Directory.Exists(modDir))
-        {
-            var backupDir = Path.Combine(installDirectory, "mods", "Reimagined.backup");
-            if (Directory.Exists(backupDir))
-            {
-                Directory.Delete(backupDir, recursive: true);
-            }
-            Directory.Move(modDir, backupDir);
-        }
+        SetInstallProgress("Installing...", "Extracting and installing mod files. Please wait.");
 
-        ZipFile.ExtractToDirectory(zipPath, installDirectory, overwriteFiles: true);
-        Notifications.SendNotification("Mod installed successfully.", "Success");
+        var profile = MainWindow.Settings.CurrentProfile;
+        if (profile.Type == InstallationType.D2RMM)
+        {
+            var result = await Task.Run(() =>
+            {
+                string? tempDir = null;
+                try
+                {
+                    tempDir = Path.Combine(Path.GetTempPath(), $"d2rmm_extract_{Guid.NewGuid():N}");
+                    Directory.CreateDirectory(tempDir);
+                    ZipFile.ExtractToDirectory(zipPath, tempDir);
+
+                    var sourceMpqDir = Path.Combine(tempDir, "mods", "Reimagined", "Reimagined.mpq");
+                    if (!Directory.Exists(sourceMpqDir))
+                        sourceMpqDir = Path.Combine(tempDir, "Reimagined", "Reimagined.mpq");
+                    if (!Directory.Exists(sourceMpqDir))
+                    {
+                        var found = Directory.GetDirectories(tempDir, "Reimagined.mpq", SearchOption.AllDirectories);
+                        if (found.Length > 0)
+                            sourceMpqDir = found[0];
+                    }
+
+                    if (!Directory.Exists(sourceMpqDir))
+                        return false;
+
+                    var targetMpqDir = Path.Combine(installDirectory, "Reimagined.mpq");
+                    if (Directory.Exists(targetMpqDir))
+                    {
+                        var backupDir = Path.Combine(installDirectory, "Reimagined.mpq.backup");
+                        if (Directory.Exists(backupDir))
+                            Directory.Delete(backupDir, recursive: true);
+                        Directory.Move(targetMpqDir, backupDir);
+                    }
+
+                    CopyDirectory(sourceMpqDir, targetMpqDir);
+                    return true;
+                }
+                finally
+                {
+                    if (tempDir != null && Directory.Exists(tempDir))
+                    {
+                        try { Directory.Delete(tempDir, true); } catch { /* ignore cleanup */ }
+                    }
+                }
+            });
+
+            if (!result)
+            {
+                Notifications.SendNotification("Reimagined.mpq not found in the mod archive.", "Warning");
+                return;
+            }
+
+            Notifications.SendNotification("Mod installed to D2RMM mods folder successfully.", "Success");
+        }
+        else
+        {
+            await Task.Run(() =>
+            {
+                var modDir = Path.Combine(installDirectory, "mods", "Reimagined");
+                if (Directory.Exists(modDir))
+                {
+                    var backupDir = Path.Combine(installDirectory, "mods", "Reimagined.backup");
+                    if (Directory.Exists(backupDir))
+                    {
+                        Directory.Delete(backupDir, recursive: true);
+                    }
+                    Directory.Move(modDir, backupDir);
+                }
+
+                ZipFile.ExtractToDirectory(zipPath, installDirectory, overwriteFiles: true);
+            });
+
+            Notifications.SendNotification("Mod installed successfully.", "Success");
+        }
 
         if (TopLevel.GetTopLevel(this) is MainWindow mainWindow)
         {
@@ -298,6 +380,15 @@ public partial class UpdateView : UserControl
             await mainWindow.RefreshUpdateStateAsync();
             await mainWindow.NavigateToLaunchViewAsync();
         }
+    }
+
+    private static void CopyDirectory(string sourceDir, string targetDir)
+    {
+        Directory.CreateDirectory(targetDir);
+        foreach (var file in Directory.GetFiles(sourceDir))
+            File.Copy(file, Path.Combine(targetDir, Path.GetFileName(file)), true);
+        foreach (var directory in Directory.GetDirectories(sourceDir))
+            CopyDirectory(directory, Path.Combine(targetDir, Path.GetFileName(directory)));
     }
 
     private static async Task<string?> WaitForNewZipFromDownloadsAsync(TimeSpan timeout)


### PR DESCRIPTION
Resolves: #53 
Resolves: #54
Resolves: #29
Resolves: #86 

Verifed with other Steam users that stean_*.dll exists regardless of OS

Fixed notification text running off to the side and being trimmed instead of wrapping.

### Add support for B.Net, Steam, and D2RMM installation separation by selection.
- Settings are saved per selected profile
- Each independently checks for mod version and etc.

### B.Net is unchanged except for having it's own settings
- Launch parameters, mod tweaks, plugins and backup locations saved specifically to profile.

### Steam
- Checks default steam/steamapps/common for D2R.exe (can be manually set if not located)
  - This checks for a steam_api*.dll to ensure it is a valid steam installation and not a Battle.Net to attempt to prevent user-errors.
- Checks the parent steam folder for steam.exe (allows manual set if not located)
- Launches the game via: `"path/steam.exe" -silent (prevents steam login popups and library/news errata if user info is saved) -applaunch 2536520 (bypasses the "hey your using parameters bro" check; #s are unique steam ID for D2R:Infernal Edition) -mod Reimagined -txt (additional selections added here)`
- Launch parameters, mod tweaks, plugins and backup locations saved specifically to profile.

### D2RMM
- Requires the user to manually select D2RMM/mods directory
    >Tested automatic location and searching D2RMM.exe but it was usually faster for me to just point it in the the right direction than wait for it to search downloads/desktop then everywhere. Can change this though if desired later.
- Directory must end at (any folder name but has D2RMM.exe inside)/mods or it is reported invalid
- Works like the others for mod installation/updates and just uses "Install Mod" to install 'Reimagined.MPQ' (D2RMM Users are used to this folder and not flat Reimagined) to the D2RMM/mods directory instead of launching a D2R.exe
- Launch parameters are entirely disabled (they don't do anything but better safe and all that...)
- Backups are not automatically enabled due to modinfo.json for D2RMM itself being set by that program, user can enable auto-backups and find the folder if they wish to keep our launcher open alongside D2RMM.
- Mod tweaks and plugins saved specifically to D2RMM profile.