### PR TITLE
feat: swap to file watcher and remove unneeded reflection for MS

### DIFF
--- a/ReimaginedLauncher/Utilities/PluginsService.cs
+++ b/ReimaginedLauncher/Utilities/PluginsService.cs
@@ -570,13 +570,10 @@ public static class PluginsService
             throw new InvalidDataException($"The column '{column}' is not supported for skills.txt.");
         }
 
-        var clonedEntry = typeof(object)
-            .GetMethod("MemberwiseClone", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(entry, null);
-
+        var clonedEntry = entry with { };
         var convertedValue = ConvertValue(updatedValue, property.PropertyType, column);
         property.SetValue(clonedEntry, convertedValue);
-        return (Skills)clonedEntry!;
+        return clonedEntry;
     }
 
     private static string? ResolveOperationValue(

--- a/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
+++ b/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
@@ -309,33 +309,37 @@ public partial class UpdateView : UserControl
         if (!Directory.Exists(downloadsFolder))
             return null;
 
-        var start = DateTime.UtcNow;
         var baseline = SnapshotZipFiles(downloadsFolder);
+        var tcs = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        while (DateTime.UtcNow - start < timeout)
-        {
-            var candidates = Directory.GetFiles(downloadsFolder, "*.zip", SearchOption.TopDirectoryOnly)
-                .OrderByDescending(path => Path.GetFileName(path).Contains("reimagined", StringComparison.OrdinalIgnoreCase))
-                .ThenByDescending(path => File.GetLastWriteTimeUtc(path))
-                .ToArray();
+        using var watcher = new FileSystemWatcher(downloadsFolder, "*.zip");
+        watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size;
+        watcher.IncludeSubdirectories = false;
+        watcher.EnableRaisingEvents = true;
 
-            foreach (var path in candidates)
-            {
-                var signature = GetFileSignature(path);
-                if (signature == null || baseline.Contains(signature))
-                    continue;
+        void OnChanged(object _, FileSystemEventArgs e) => TryResolve(e.FullPath, baseline, tcs);
+        watcher.Created += OnChanged;
+        watcher.Changed += OnChanged;
 
-                if (!IsFileReady(path))
-                    continue;
+        using var cts = new System.Threading.CancellationTokenSource(timeout);
+        cts.Token.Register(() => tcs.TrySetResult(null));
 
-                if (IsZipArchive(path))
-                    return path;
-            }
+        return await tcs.Task;
+    }
 
-            await Task.Delay(TimeSpan.FromSeconds(2));
-        }
+    private static void TryResolve(string path, HashSet<string> baseline, TaskCompletionSource<string?> tcs)
+    {
+        if (tcs.Task.IsCompleted)
+            return;
 
-        return null;
+        var signature = GetFileSignature(path);
+        if (signature == null || baseline.Contains(signature))
+            return;
+
+        if (!IsFileReady(path) || !IsZipArchive(path))
+            return;
+
+        tcs.TrySetResult(path);
     }
 
     private static HashSet<string> SnapshotZipFiles(string folder)


### PR DESCRIPTION
* Removes the use of reflection for less-sketchy method of cloning skills
* Swaps to file watcher instead of polling for more native control