### PR TITLE
Backup summary on main

### DIFF
--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml
@@ -39,10 +39,10 @@
                         <StackPanel VerticalAlignment="Center" Spacing="2">
                             <TextBlock x:Name="BackupOnLaunchSummary"
                                        Classes="muted"
-                                       FontSize="12" />
+                                       FontSize="14" />
                             <TextBlock x:Name="BackupIntervalSummary"
                                        Classes="muted"
-                                       FontSize="12" />
+                                       FontSize="14" />
                         </StackPanel>
                     </StackPanel>
                 </StackPanel>

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml
@@ -26,16 +26,25 @@
                                Classes="muted"
                                Text="The button stays available here and will enable once the install directory is valid and the mod is detected."
                                TextWrapping="Wrap" />
-                    <Button x:Name="StartGameButton"
-                            Classes="accent"
-                            Content="Start Game"
-                            Click="OnRunClick"
-                            Width="220"
-                            HorizontalAlignment="Left"
-                            HorizontalContentAlignment="Center"
-                            VerticalContentAlignment="Center"
-                            MinHeight="48"
-                            IsEnabled="False" />
+                    <StackPanel Orientation="Horizontal" Spacing="16">
+                        <Button x:Name="StartGameButton"
+                                Classes="accent"
+                                Content="Start Game"
+                                Click="OnRunClick"
+                                Width="220"
+                                HorizontalContentAlignment="Center"
+                                VerticalContentAlignment="Center"
+                                MinHeight="48"
+                                IsEnabled="False" />
+                        <StackPanel VerticalAlignment="Center" Spacing="2">
+                            <TextBlock x:Name="BackupOnLaunchSummary"
+                                       Classes="muted"
+                                       FontSize="12" />
+                            <TextBlock x:Name="BackupIntervalSummary"
+                                       Classes="muted"
+                                       FontSize="12" />
+                        </StackPanel>
+                    </StackPanel>
                 </StackPanel>
             </Border>
 

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -171,6 +171,11 @@ public partial class LaunchView : UserControl
         }
         
         LaunchCommandText.Text = LauncherService.BuildLaunchCommand();
+
+        BackupOnLaunchSummary.Text = $"Backup on Launch: {(profile.AutomaticBackupsEnabled ? "Yes" : "No")}";
+        BackupIntervalSummary.Text = profile.AutomaticBackupsEnabled
+            ? $"Backup Automatic Interval: {profile.BackupIntervalMinutes} min"
+            : "Backup Automatic Interval: No";
     }
 
     private async void OnInstallationTypeChanged(object? sender, SelectionChangedEventArgs e)

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -174,8 +174,8 @@ public partial class LaunchView : UserControl
 
         BackupOnLaunchSummary.Text = $"Backup on Launch: {(profile.AutomaticBackupsEnabled ? "Yes" : "No")}";
         BackupIntervalSummary.Text = profile.AutomaticBackupsEnabled
-            ? $"Backup Automatic Interval: {profile.BackupIntervalMinutes} min"
-            : "Backup Automatic Interval: No";
+            ? $"Auto-Backup Interval: {profile.BackupIntervalMinutes} min"
+            : "Auto-Backup Interval: N/A";
     }
 
     private async void OnInstallationTypeChanged(object? sender, SelectionChangedEventArgs e)


### PR DESCRIPTION
Resolves: #48 

The only reason I made the attempt is because of the D2RMM being automatically disabled due to the nature of that launcher's operation also requiring an install button be clicked before you even know where the saves are at.

Enabled on a timer:
<img width="1432" height="799" alt="image" src="https://github.com/user-attachments/assets/9904677b-7a0b-483e-9eef-f596b08d790e" />

Disabled:
<img width="1072" height="706" alt="image" src="https://github.com/user-attachments/assets/b932693b-a8af-4c73-a708-838b0cc23368" />