### PR TITLE
Tray Icon & Window Size Support

### DIFF
--- a/ReimaginedLauncher/MainWindow.axaml.cs
+++ b/ReimaginedLauncher/MainWindow.axaml.cs
@@ -22,6 +22,7 @@ using ReimaginedLauncher.HttpClients.Models;
 using ReimaginedLauncher.Utilities;
 using ReimaginedLauncher.Utilities.Json;
 using ReimaginedLauncher.Utilities.ViewModels;
+using Avalonia;
 using ReimaginedLauncher.Views.Backups;
 using ReimaginedLauncher.Views.Launch;
 using ReimaginedLauncher.Views.ModTweaks;
@@ -67,11 +68,14 @@ public partial class MainWindow : Window
     private double _currentScale = 1.0;
     private TrayIcon? _trayIcon;
     private bool _isExiting;
+    private readonly DispatcherTimer _saveWindowStateTimer;
+    private bool _isRestoringWindowState;
 
     public MainWindow()
     {
         _gitHubAnnouncementsHttpClient = Program.ServiceProvider.GetRequiredService<GitHubAnnouncementsHttpClient>();
         _nexusModsHttpClient = Program.ServiceProvider.GetRequiredService<NexusModsHttpClient>();;
+        Opacity = 0;
         InitializeComponent();
         NotificationManager = new WindowNotificationManager(this)
         {
@@ -94,6 +98,14 @@ public partial class MainWindow : Window
         // Set the window icon
         Icon = new WindowIcon("Assets/ReimaginedLauncher.ico");
         InitializeTrayIcon();
+        _saveWindowStateTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(500) };
+        _saveWindowStateTimer.Tick += async (_, _) =>
+        {
+            _saveWindowStateTimer.Stop();
+            await SettingsManager.SaveAsync(Settings);
+        };
+        PositionChanged += OnWindowPositionOrSizeChanged;
+        SizeChanged += OnWindowPositionOrSizeChanged;
     }
 
     private static string ResolveLauncherVersion()
@@ -115,6 +127,8 @@ public partial class MainWindow : Window
     private async Task LoadSettingsAsync()
     {
         Settings = await SettingsManager.LoadAsync();
+        RestoreWindowState();
+        Opacity = 1;
         Settings.UiScale = ClampUiScale(Settings.UiScale);
         var profile = Settings.CurrentProfile;
         profile.InstallDirectory = InstallDirectoryValidator.NormalizeInstallDirectory(profile.InstallDirectory);
@@ -1121,9 +1135,96 @@ public partial class MainWindow : Window
         Dispatcher.UIThread.Post(() =>
         {
             Show();
-            WindowState = WindowState.Normal;
+            WindowState = Settings.IsMaximized ? WindowState.Maximized : WindowState.Normal;
             Activate();
         });
+    }
+
+    private void RestoreWindowState()
+    {
+        _isRestoringWindowState = true;
+        try
+        {
+            if (Settings.WindowWidth.HasValue && Settings.WindowHeight.HasValue)
+            {
+                Width = Settings.WindowWidth.Value;
+                Height = Settings.WindowHeight.Value;
+            }
+
+            if (Settings.WindowX.HasValue && Settings.WindowY.HasValue)
+            {
+                var x = (int)Settings.WindowX.Value;
+                var y = (int)Settings.WindowY.Value;
+                var w = (int)(Settings.WindowWidth ?? Width);
+                var h = (int)(Settings.WindowHeight ?? Height);
+
+                if (IsPositionWithinScreenBounds(x, y, w, h))
+                {
+                    Position = new PixelPoint(x, y);
+                    WindowStartupLocation = WindowStartupLocation.Manual;
+                }
+            }
+
+            if (Settings.IsMaximized)
+            {
+                WindowState = WindowState.Maximized;
+            }
+        }
+        finally
+        {
+            _isRestoringWindowState = false;
+        }
+    }
+
+    private bool IsPositionWithinScreenBounds(int x, int y, int width, int height)
+    {
+        var screens = Screens;
+        if (screens.ScreenCount == 0)
+            return false;
+
+        // Check that at least a meaningful portion of the window is visible on some screen
+        const int minVisiblePixels = 50;
+        foreach (var screen in screens.All)
+        {
+            var workArea = screen.WorkingArea;
+            var overlapLeft = Math.Max(x, workArea.X);
+            var overlapTop = Math.Max(y, workArea.Y);
+            var overlapRight = Math.Min(x + width, workArea.X + workArea.Width);
+            var overlapBottom = Math.Min(y + height, workArea.Y + workArea.Height);
+
+            if (overlapRight - overlapLeft >= minVisiblePixels && overlapBottom - overlapTop >= minVisiblePixels)
+                return true;
+        }
+
+        return false;
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == WindowStateProperty)
+        {
+            OnWindowPositionOrSizeChanged(null, EventArgs.Empty);
+        }
+    }
+
+    private void OnWindowPositionOrSizeChanged(object? sender, EventArgs e)
+    {
+        if (_isRestoringWindowState)
+            return;
+
+        Settings.IsMaximized = WindowState == WindowState.Maximized;
+
+        if (WindowState == WindowState.Normal)
+        {
+            Settings.WindowWidth = Bounds.Width;
+            Settings.WindowHeight = Bounds.Height;
+            Settings.WindowX = Position.X;
+            Settings.WindowY = Position.Y;
+        }
+
+        _saveWindowStateTimer?.Stop();
+        _saveWindowStateTimer?.Start();
     }
 
     private void ExitFromTray()

--- a/ReimaginedLauncher/MainWindow.axaml.cs
+++ b/ReimaginedLauncher/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -64,6 +65,8 @@ public partial class MainWindow : Window
     private NexusModsSSO? _nexusSSO;
     private string? _localModVersion;
     private double _currentScale = 1.0;
+    private TrayIcon? _trayIcon;
+    private bool _isExiting;
 
     public MainWindow()
     {
@@ -90,6 +93,7 @@ public partial class MainWindow : Window
         
         // Set the window icon
         Icon = new WindowIcon("Assets/ReimaginedLauncher.ico");
+        InitializeTrayIcon();
     }
 
     private static string ResolveLauncherVersion()
@@ -1089,6 +1093,87 @@ public partial class MainWindow : Window
         Notifications.SendNotification("Logged out of Nexus Mods.", "Success");
     }
     
+    private void InitializeTrayIcon()
+    {
+        var showItem = new NativeMenuItem("Show Launcher");
+        showItem.Click += (_, _) => RestoreFromTray();
+
+        var exitItem = new NativeMenuItem("Exit Launcher");
+        exitItem.Click += (_, _) => ExitFromTray();
+
+        _trayIcon = new TrayIcon
+        {
+            Icon = Icon,
+            ToolTipText = "D2R Reimagined Launcher",
+            IsVisible = true,
+            Menu = new NativeMenu { showItem, exitItem }
+        };
+        _trayIcon.Clicked += (_, _) => RestoreFromTray();
+    }
+
+    public void MinimizeToTray()
+    {
+        Hide();
+    }
+
+    public void RestoreFromTray()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            Show();
+            WindowState = WindowState.Normal;
+            Activate();
+        });
+    }
+
+    private void ExitFromTray()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            _isExiting = true;
+            _trayIcon?.Dispose();
+            _trayIcon = null;
+            Close();
+        });
+    }
+
+    protected override void OnClosing(WindowClosingEventArgs e)
+    {
+        if (!_isExiting && Settings.MinimizeToTrayOnClose)
+        {
+            e.Cancel = true;
+            MinimizeToTray();
+            return;
+        }
+
+        _trayIcon?.Dispose();
+        _trayIcon = null;
+        base.OnClosing(e);
+    }
+
+    public async Task MinimizeToTrayAndWaitForExitAsync(Process gameProcess)
+    {
+        MinimizeToTray();
+
+        await Task.Run(() =>
+        {
+            try
+            {
+                gameProcess.WaitForExit();
+            }
+            catch (InvalidOperationException)
+            {
+                // Process already exited or handle is invalid
+            }
+            finally
+            {
+                gameProcess.Dispose();
+            }
+        });
+
+        RestoreFromTray();
+    }
+
     private async Task ValidateKey()
     {
         await SettingsManager.SaveAsync(Settings);

--- a/ReimaginedLauncher/MainWindow.axaml.cs
+++ b/ReimaginedLauncher/MainWindow.axaml.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Text.Json;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
@@ -1252,15 +1253,29 @@ public partial class MainWindow : Window
         base.OnClosing(e);
     }
 
-    public async Task MinimizeToTrayAndWaitForExitAsync(Process gameProcess)
+    public async Task MinimizeToTrayAndWaitForExitAsync(Process gameProcess, string? expectedExePath = null)
     {
         MinimizeToTray();
 
         await Task.Run(() =>
         {
+            Process? processToWatch = null;
             try
             {
-                gameProcess.WaitForExit();
+                // When launched via Steam, the returned process is Steam.exe, not the game.
+                // Poll briefly to find the actual D2R.exe process by its executable path.
+                processToWatch = gameProcess;
+                if (!string.IsNullOrEmpty(expectedExePath))
+                {
+                    var found = WaitForProcessByPath(expectedExePath, timeout: TimeSpan.FromSeconds(60));
+                    if (found != null)
+                    {
+                        gameProcess.Dispose();
+                        processToWatch = found;
+                    }
+                }
+
+                processToWatch.WaitForExit();
             }
             catch (InvalidOperationException)
             {
@@ -1268,11 +1283,51 @@ public partial class MainWindow : Window
             }
             finally
             {
-                gameProcess.Dispose();
+                processToWatch?.Dispose();
             }
         });
 
         RestoreFromTray();
+    }
+
+    private static Process? WaitForProcessByPath(string exePath, TimeSpan timeout)
+    {
+        var processName = Path.GetFileNameWithoutExtension(exePath);
+        var normalizedTarget = Path.GetFullPath(exePath);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                foreach (var proc in Process.GetProcessesByName(processName))
+                {
+                    try
+                    {
+                        var mainModule = proc.MainModule;
+                        if (mainModule != null &&
+                            string.Equals(Path.GetFullPath(mainModule.FileName), normalizedTarget, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return proc;
+                        }
+                    }
+                    catch
+                    {
+                        // Access denied or process exited — skip
+                    }
+
+                    proc.Dispose();
+                }
+            }
+            catch
+            {
+                // Enumeration failed — retry
+            }
+
+            Thread.Sleep(2000);
+        }
+
+        return null;
     }
 
     private async Task ValidateKey()

--- a/ReimaginedLauncher/Utilities/AppSettings.cs
+++ b/ReimaginedLauncher/Utilities/AppSettings.cs
@@ -45,6 +45,8 @@ public class InstallationProfile
 public class AppSettings
 {
     public double UiScale { get; set; } = 1.0;
+    public bool MinimizeToTray { get; set; }
+    public bool MinimizeToTrayOnClose { get; set; }
     public int LastReadAnnouncementNumber { get; set; }
     public string? NexusModsSSOApiKey { get; set; }
     public bool? NexusPremiumDownloadAccess { get; set; }

--- a/ReimaginedLauncher/Utilities/AppSettings.cs
+++ b/ReimaginedLauncher/Utilities/AppSettings.cs
@@ -47,6 +47,11 @@ public class AppSettings
     public double UiScale { get; set; } = 1.0;
     public bool MinimizeToTray { get; set; }
     public bool MinimizeToTrayOnClose { get; set; }
+    public double? WindowWidth { get; set; }
+    public double? WindowHeight { get; set; }
+    public double? WindowX { get; set; }
+    public double? WindowY { get; set; }
+    public bool IsMaximized { get; set; }
     public int LastReadAnnouncementNumber { get; set; }
     public string? NexusModsSSOApiKey { get; set; }
     public bool? NexusPremiumDownloadAccess { get; set; }

--- a/ReimaginedLauncher/Utilities/GameLauncherService.cs
+++ b/ReimaginedLauncher/Utilities/GameLauncherService.cs
@@ -437,12 +437,12 @@ public class GameLauncherService
         return $"\"{executablePath}\" {launchParameters}";
     }
 
-    public void LaunchGame(string? launchParamOverride = null, string? gamePathOverride = null)
+    public Process? LaunchGame(string? launchParamOverride = null, string? gamePathOverride = null)
     {
         var profile = MainWindow.Settings.CurrentProfile;
         
         // D2RMM handled separately in LaunchView
-        if (profile.Type == InstallationType.D2RMM) return;
+        if (profile.Type == InstallationType.D2RMM) return null;
 
         if (!string.IsNullOrWhiteSpace(gamePathOverride))
         {
@@ -464,7 +464,7 @@ public class GameLauncherService
             if (!File.Exists(executablePath))
             {
                 Notifications.SendNotification($"Steam.exe not found at {executablePath}. Please locate it in the Install Directory section.");
-                return;
+                return null;
             }
         }
         else
@@ -475,7 +475,7 @@ public class GameLauncherService
             if (string.IsNullOrWhiteSpace(executablePath))
             {
                 Notifications.SendNotification("No valid game path found. Please set the game path in settings.");
-                return;
+                return null;
             }
         }
 
@@ -485,7 +485,7 @@ public class GameLauncherService
         if (!OperatingSystem.IsWindows())
         {
             Notifications.SendNotification("This only works on Windows");
-            return;
+            return null;
         }
 
         var processStartInfo = new ProcessStartInfo(executablePath)
@@ -501,15 +501,17 @@ public class GameLauncherService
             {
                 LaunchDiagnostics.Log("Process.Start returned null.");
                 Notifications.SendNotification($"Failed to start {Path.GetFileName(executablePath)}.", "Warning");
-                return;
+                return null;
             }
 
             LaunchDiagnostics.Log($"Process started with PID {process.Id}.");
+            return process;
         }
         catch (Win32Exception ex)
         {
             LaunchDiagnostics.LogException("Process.Start failed", ex);
             Notifications.SendNotification($"Failed to start {Path.GetFileName(executablePath)}: {ex.Message}", "Warning");
+            return null;
         }
     }
 

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -310,9 +310,14 @@ public partial class LaunchView : UserControl
                 {
                     LaunchDiagnostics.Log("Calling GameLauncherService.LaunchGame.");
                     SetLaunchStatus("Starting Diablo II: Resurrected...");
-                    LauncherService.LaunchGame();
+                    var gameProcess = LauncherService.LaunchGame();
                     LaunchDiagnostics.Log("GameLauncherService.LaunchGame returned without throwing.");
                     SetLaunchStatus($"{actionName} command sent.");
+
+                    if (gameProcess != null && MainWindow.Settings.MinimizeToTray && TopLevel.GetTopLevel(this) is MainWindow mainWindow)
+                    {
+                        _ = mainWindow.MinimizeToTrayAndWaitForExitAsync(gameProcess);
+                    }
                 }
             }
             catch (Exception ex)

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -316,7 +316,15 @@ public partial class LaunchView : UserControl
 
                     if (gameProcess != null && MainWindow.Settings.MinimizeToTray && TopLevel.GetTopLevel(this) is MainWindow mainWindow)
                     {
-                        _ = mainWindow.MinimizeToTrayAndWaitForExitAsync(gameProcess);
+                        // For Steam launches, pass the actual D2R.exe path so the launcher
+                        // waits for the game process rather than the Steam bootstrapper.
+                        string? expectedExePath = null;
+                        if (profile.Type == InstallationType.Steam)
+                        {
+                            expectedExePath = InstallDirectoryValidator.GetExecutablePath(profile.InstallDirectory);
+                        }
+
+                        _ = mainWindow.MinimizeToTrayAndWaitForExitAsync(gameProcess, expectedExePath);
                     }
                 }
             }

--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml
@@ -112,6 +112,24 @@
                             <ComboBoxItem Content="100%"/>
                         </ComboBox>
                     </StackPanel>
+                    <StackPanel Spacing="4">
+                        <CheckBox x:Name="MinimizeToTrayCheckBox"
+                                  Content="Minimize to tray on game launch"
+                                  IsCheckedChanged="OnMinimizeToTrayChanged"/>
+                        <TextBlock Classes="muted"
+                                   Margin="28,0,0,0"
+                                   TextWrapping="Wrap"
+                                   Text="Minimizes the launcher to the system tray when the game starts and restores it when the game exits." />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <CheckBox x:Name="MinimizeToTrayOnCloseCheckBox"
+                                  Content="Minimize to tray when window is closed"
+                                  IsCheckedChanged="OnMinimizeToTrayOnCloseChanged"/>
+                        <TextBlock Classes="muted"
+                                   Margin="28,0,0,0"
+                                   TextWrapping="Wrap"
+                                   Text="Minimizes the launcher to the system tray instead of exiting when the window is closed. Use the tray icon to exit." />
+                    </StackPanel>
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
@@ -50,6 +50,9 @@ public partial class SettingsView : UserControl
                 : 0;
         }
 
+        MinimizeToTrayCheckBox.IsChecked = MainWindow.Settings.MinimizeToTray;
+        MinimizeToTrayOnCloseCheckBox.IsChecked = MainWindow.Settings.MinimizeToTrayOnClose;
+
         _isRefreshingSettings = false;
     }
 
@@ -82,6 +85,28 @@ public partial class SettingsView : UserControl
             _ => null
         };
 
+        await SettingsManager.SaveAsync(MainWindow.Settings);
+    }
+
+    private async void OnMinimizeToTrayChanged(object? sender, RoutedEventArgs e)
+    {
+        if (_isRefreshingSettings)
+        {
+            return;
+        }
+
+        MainWindow.Settings.MinimizeToTray = MinimizeToTrayCheckBox.IsChecked ?? false;
+        await SettingsManager.SaveAsync(MainWindow.Settings);
+    }
+
+    private async void OnMinimizeToTrayOnCloseChanged(object? sender, RoutedEventArgs e)
+    {
+        if (_isRefreshingSettings)
+        {
+            return;
+        }
+
+        MainWindow.Settings.MinimizeToTrayOnClose = MinimizeToTrayOnCloseCheckBox.IsChecked ?? false;
         await SettingsManager.SaveAsync(MainWindow.Settings);
     }
 


### PR DESCRIPTION
Resolves: #96 
Resolves: #97

Tray icon support
- Settings for launch game to tray and for close window to tray added, disabled by default.
- Launcher will re-open from tray once the game window is closed. 
    >Compiled to check it out locally and with Virus Total. Nothing introduced is flagged or considered malicious not even via Trapmine, lol.
- I ensured it is using system diagnostics checks only for the steam.exe -> d2r.exe transfer for restoring launcher from tray on app close..

Launcher remembers window position and maximize/restore on exit and re-open.
- Default first launch behavior is unchanged but it will re-maximize if it is closed while maximized.
    >If you want it to open that way, close it that way.  I need cow emotes on here. 😭 