### PR TITLE
D2RMM Install Path Fix

### DIFF
--- a/ReimaginedLauncher/MainWindow.axaml.cs
+++ b/ReimaginedLauncher/MainWindow.axaml.cs
@@ -495,11 +495,11 @@ public partial class MainWindow : Window
         {
             if (!string.IsNullOrWhiteSpace(profile.InstallDirectory))
             {
-                var modPath = Path.Combine(profile.InstallDirectory, "Reimagined.mpq");
-                var modInfoPath = Path.Combine(modPath, "modinfo.json");
-                var layoutsDir = Path.Combine(modPath, "data", "global", "ui", "layouts");
+                var modPath = InstallDirectoryValidator.ResolveD2RmmModFolder(profile.InstallDirectory);
+                IsLocalModDetected = modPath != null;
 
-                IsLocalModDetected = Directory.Exists(modPath);
+                var modInfoPath = modPath != null ? Path.Combine(modPath, "modinfo.json") : string.Empty;
+                var layoutsDir = modPath != null ? Path.Combine(modPath, "data", "global", "ui", "layouts") : string.Empty;
 
                 var panel = CharacterSelectPanelService.FromJson(layoutsDir);
                 var panelVersion = panel?.GetModVersion();

--- a/ReimaginedLauncher/Utilities/BackupService.cs
+++ b/ReimaginedLauncher/Utilities/BackupService.cs
@@ -621,7 +621,10 @@ public static class BackupService
 
         if (profile.Type == InstallationType.D2RMM)
         {
-            var d2rmmPath = Path.Combine(installDirectory, "Reimagined.mpq", "modinfo.json");
+            var resolvedFolder = InstallDirectoryValidator.ResolveD2RmmModFolder(installDirectory);
+            if (resolvedFolder == null)
+                return null;
+            var d2rmmPath = Path.Combine(resolvedFolder, "modinfo.json");
             return File.Exists(d2rmmPath) ? d2rmmPath : null;
         }
 

--- a/ReimaginedLauncher/Utilities/GameLauncherService.cs
+++ b/ReimaginedLauncher/Utilities/GameLauncherService.cs
@@ -420,7 +420,7 @@ public class GameLauncherService
         var profile = MainWindow.Settings.CurrentProfile;
         if (profile.Type == InstallationType.D2RMM)
         {
-            return "D2RMM Install: No launch command. Clicking install mod will install reimagined.mpq into D2RMM/mods.";
+            return "D2RMM Install: No launch command. Clicking install mod will install Reimagined into D2RMM/mods.";
         }
 
         var launchParameters = string.IsNullOrWhiteSpace(launchParamOverride)

--- a/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
+++ b/ReimaginedLauncher/Utilities/InstallDirectoryValidator.cs
@@ -87,4 +87,30 @@ public static class InstallDirectoryValidator
         var executablePath = Path.Combine(normalizedDirectory, ExecutableName);
         return File.Exists(executablePath) ? executablePath : null;
     }
+
+    /// <summary>
+    /// Resolves the D2RMM mod folder inside the given mods directory.
+    /// Accepts either "Reimagined" or "Reimagined.mpq" as long as the folder
+    /// contains a "data" subfolder with a "modinfo.json" file.
+    /// Prefers "Reimagined" over "Reimagined.mpq" when both exist.
+    /// </summary>
+    public static string? ResolveD2RmmModFolder(string? modsDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(modsDirectory))
+            return null;
+
+        var candidates = new[] { "Reimagined", "Reimagined.mpq" };
+        foreach (var candidate in candidates)
+        {
+            var candidatePath = Path.Combine(modsDirectory, candidate);
+            if (Directory.Exists(candidatePath) &&
+                Directory.Exists(Path.Combine(candidatePath, "data")) &&
+                File.Exists(Path.Combine(candidatePath, "modinfo.json")))
+            {
+                return candidatePath;
+            }
+        }
+
+        return null;
+    }
 }

--- a/ReimaginedLauncher/Utilities/ModTweaksService.cs
+++ b/ReimaginedLauncher/Utilities/ModTweaksService.cs
@@ -217,9 +217,13 @@ public static class ModTweaksService
             return null;
         }
 
-        return profile.Type == InstallationType.D2RMM
-            ? Path.Combine(installDirectory, $"{ModDirectoryName}.mpq")
-            : Path.Combine(installDirectory, "mods", ModDirectoryName, $"{ModDirectoryName}.mpq");
+        if (profile.Type == InstallationType.D2RMM)
+        {
+            return InstallDirectoryValidator.ResolveD2RmmModFolder(installDirectory) ??
+                   Path.Combine(installDirectory, ModDirectoryName);
+        }
+
+        return Path.Combine(installDirectory, "mods", ModDirectoryName, $"{ModDirectoryName}.mpq");
     }
 
     private static string? GetExcelDirectory()

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -109,12 +109,12 @@ public partial class LaunchView : UserControl
         if (profile.Type == InstallationType.D2RMM)
         {
             InstallDirectoryTitle.Text = "D2RMM Mods Folder";
-            InstallDirectoryDescription.Text = "Select your D2RMM mods folder where Reimagined.mpq will be installed.";
+            InstallDirectoryDescription.Text = "Select your D2RMM mods folder where Reimagined will be installed.";
             
             isValidated = InstallDirectoryValidator.IsValidD2RmmModsDirectory(profile.InstallDirectory) && Directory.Exists(profile.InstallDirectory);
             
-            // For D2RMM, check if Reimagined.mpq exists in the mods folder
-            isModDetected = isValidated && Directory.Exists(Path.Combine(profile.InstallDirectory!, "Reimagined.mpq"));
+            // For D2RMM, check if Reimagined or Reimagined.mpq exists in the mods folder
+            isModDetected = isValidated && InstallDirectoryValidator.ResolveD2RmmModFolder(profile.InstallDirectory) != null;
         }
         else
         {
@@ -131,7 +131,7 @@ public partial class LaunchView : UserControl
         if (profile.Type == InstallationType.D2RMM)
         {
             StartGameButton.Content = "Install Tweaks";
-            StartGameDescription.Text = "Clicking 'Install Tweaks' will apply tweaks and adjustments to the files in your D2RMM/mods/Reimagined.mpq/data directory.";
+            StartGameDescription.Text = "Clicking 'Install Tweaks' will apply tweaks and adjustments to the files in your D2RMM/mods/Reimagined/data directory.";
             StartGameButton.IsEnabled = !_isLaunching && isValidated && isModDetected;
         }
         else
@@ -155,7 +155,7 @@ public partial class LaunchView : UserControl
                 : !InstallDirectoryValidator.IsValidD2RmmModsDirectory(profile.InstallDirectory)
                     ? InstallDirectoryValidator.GetD2RmmValidationMessage(profile.InstallDirectory)
                     : !isModDetected && isValidated
-                        ? "Reimagined.mpq not yet installed in this mods folder."
+                        ? "Reimagined not yet installed in this mods folder."
                         : "The selected folder could not be found.";
         }
         else

--- a/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
+++ b/ReimaginedLauncher/Views/Update/UpdateView.axaml.cs
@@ -330,28 +330,29 @@ public partial class UpdateView : UserControl
                     Directory.CreateDirectory(tempDir);
                     ZipFile.ExtractToDirectory(zipPath, tempDir);
 
-                    var sourceMpqDir = Path.Combine(tempDir, "mods", "Reimagined", "Reimagined.mpq");
-                    if (!Directory.Exists(sourceMpqDir))
-                        sourceMpqDir = Path.Combine(tempDir, "Reimagined", "Reimagined.mpq");
-                    if (!Directory.Exists(sourceMpqDir))
-                    {
-                        var found = Directory.GetDirectories(tempDir, "Reimagined.mpq", SearchOption.AllDirectories);
-                        if (found.Length > 0)
-                            sourceMpqDir = found[0];
-                    }
+                    var sourceMpqDir = ResolveSourceModFolder(tempDir);
 
-                    if (!Directory.Exists(sourceMpqDir))
+                    if (sourceMpqDir == null || !Directory.Exists(sourceMpqDir))
                         return false;
 
-                    var targetMpqDir = Path.Combine(installDirectory, "Reimagined.mpq");
+                    var targetMpqDir = Path.Combine(installDirectory, "Reimagined");
                     if (Directory.Exists(targetMpqDir))
                         Directory.Delete(targetMpqDir, recursive: true);
 
+                    // Also clean up legacy Reimagined.mpq folder if present
+                    var legacyTargetDir = Path.Combine(installDirectory, "Reimagined.mpq");
+                    if (Directory.Exists(legacyTargetDir))
+                        Directory.Delete(legacyTargetDir, recursive: true);
+
                     CopyDirectory(sourceMpqDir, targetMpqDir);
 
-                    var backupDir = Path.Combine(installDirectory, "Reimagined.mpq.backup");
+                    var backupDir = Path.Combine(installDirectory, "Reimagined.backup");
                     if (Directory.Exists(backupDir))
                         Directory.Delete(backupDir, recursive: true);
+
+                    var legacyBackupDir = Path.Combine(installDirectory, "Reimagined.mpq.backup");
+                    if (Directory.Exists(legacyBackupDir))
+                        Directory.Delete(legacyBackupDir, recursive: true);
 
                     return true;
                 }
@@ -366,7 +367,7 @@ public partial class UpdateView : UserControl
 
             if (!result)
             {
-                Notifications.SendNotification("Reimagined.mpq not found in the mod archive.", "Warning");
+                Notifications.SendNotification("Reimagined mod folder not found in the mod archive.", "Warning");
                 return;
             }
 
@@ -401,6 +402,43 @@ public partial class UpdateView : UserControl
             await mainWindow.RefreshUpdateStateAsync();
             await mainWindow.NavigateToLaunchViewAsync();
         }
+    }
+
+    private static string? ResolveSourceModFolder(string tempDir)
+    {
+        string[] searchPaths =
+        [
+            Path.Combine(tempDir, "mods", "Reimagined", "Reimagined"),
+            Path.Combine(tempDir, "mods", "Reimagined", "Reimagined.mpq"),
+            Path.Combine(tempDir, "Reimagined", "Reimagined"),
+            Path.Combine(tempDir, "Reimagined", "Reimagined.mpq")
+        ];
+
+        foreach (var path in searchPaths)
+        {
+            if (Directory.Exists(path) &&
+                Directory.Exists(Path.Combine(path, "data")) &&
+                File.Exists(Path.Combine(path, "modinfo.json")))
+            {
+                return path;
+            }
+        }
+
+        // Fallback: search recursively for either folder name containing data/modinfo.json
+        foreach (var name in new[] { "Reimagined", "Reimagined.mpq" })
+        {
+            var found = Directory.GetDirectories(tempDir, name, SearchOption.AllDirectories);
+            foreach (var dir in found)
+            {
+                if (Directory.Exists(Path.Combine(dir, "data")) &&
+                    File.Exists(Path.Combine(dir, "modinfo.json")))
+                {
+                    return dir;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static void CopyDirectory(string sourceDir, string targetDir)


### PR DESCRIPTION
Resolves: #114 

Launcher will now accept Reimagined or Reimagined.mpq as a valid path for D2RMM as long as the subfolder is data and contains modinfo.json

Prefers Reimagined and will cleanup old Reimagined.mpq by renaming into Reimagined

Will need to either update this to include armor tweak fix or vice-versa as currently they are seperate PRs.