### PR TITLE
Plugin add append operator

### DIFF
--- a/ReimaginedLauncher/Utilities/PluginsService.cs
+++ b/ReimaginedLauncher/Utilities/PluginsService.cs
@@ -505,7 +505,7 @@ public static class PluginsService
 
     public static string GetSupportedTargetsSummary()
     {
-        return "Supported now: skills.txt (matched on Skill) and cubemain.txt (matched on Description). Multiply-existing operations can reference parameters declared in plugininfo.json.";
+        return "Supported now: skills.txt (matched on Skill) and cubemain.txt (matched on Description). Multiply-existing and append operations can reference parameters declared in plugininfo.json.";
     }
 
     private static async Task ApplyOperationsAsync(
@@ -657,6 +657,27 @@ public static class PluginsService
             }
 
             return FormatDecimalValue(currentNumber * multiplier);
+        }
+
+        if (operationType.Equals("append", StringComparison.OrdinalIgnoreCase))
+        {
+            var column = operation.Column ?? string.Empty;
+            var property = typeof(TEntry).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(candidate => candidate.Name.Equals(column, StringComparison.OrdinalIgnoreCase));
+
+            if (property == null)
+            {
+                throw new InvalidDataException($"The column '{column}' is not supported for {fileName}.");
+            }
+
+            var currentValue = property.GetValue(entry)?.ToString() ?? string.Empty;
+
+            var appendText = !string.IsNullOrWhiteSpace(operation.ParameterKey) &&
+                             parameters.TryGetValue(operation.ParameterKey, out var parameterValue)
+                ? parameterValue
+                : resolvedUpdatedValue ?? string.Empty;
+
+            return $"({currentValue}){appendText}";
         }
 
         throw new InvalidDataException($"Unsupported plugin operation '{operationType}'.");
@@ -919,11 +940,12 @@ public static class PluginsService
             }
 
             if (!string.IsNullOrWhiteSpace(operation.Operation) &&
-                operation.Operation.Equals("multiplyExisting", StringComparison.OrdinalIgnoreCase) &&
+                (operation.Operation.Equals("multiplyExisting", StringComparison.OrdinalIgnoreCase) ||
+                 operation.Operation.Equals("append", StringComparison.OrdinalIgnoreCase)) &&
                 string.IsNullOrWhiteSpace(operation.ParameterKey) &&
                 string.IsNullOrWhiteSpace(operation.UpdatedValue))
             {
-                errors.Add($"'{pluginFileName}' contains a multiplyExisting operation without parameterKey or updatedValue.");
+                errors.Add($"'{pluginFileName}' contains a {operation.Operation} operation without parameterKey or updatedValue.");
             }
 
             if (!string.IsNullOrWhiteSpace(operation.ParameterKey) &&

--- a/ReimaginedLauncher/Views/Plugins/PluginAuthoringGuideView.axaml
+++ b/ReimaginedLauncher/Views/Plugins/PluginAuthoringGuideView.axaml
@@ -83,8 +83,8 @@
                     <TextBlock Text="file: Required. Must be skills.txt or cubemain.txt." TextWrapping="Wrap" />
                     <TextBlock Text="rowIdentifier: Required. For skills.txt it must match a row's Skill value. For cubemain.txt it must match a row's Description value." TextWrapping="Wrap" />
                     <TextBlock Text="column: Required. Must match a real column name on the target file's generated parser model." TextWrapping="Wrap" />
-                    <TextBlock Text="updatedValue: The replacement value, or the multiplier when operation is multiplyExisting and parameterKey is not used." TextWrapping="Wrap" />
-                    <TextBlock Text="operation: Optional. Leave empty or use replace for direct replacement. Use multiplyExisting to multiply the current numeric value." TextWrapping="Wrap" />
+                    <TextBlock Text="updatedValue: The replacement value, the multiplier when operation is multiplyExisting, or the text appended when operation is append. Required when parameterKey is not used." TextWrapping="Wrap" />
+                    <TextBlock Text="operation: Optional. Leave empty or use replace for direct replacement. Use multiplyExisting to multiply the current numeric value. Use append to wrap the existing value in parentheses and concatenate your entry, e.g. (existingValue)+10*20." TextWrapping="Wrap" />
                     <TextBlock Text="parameterKey: Optional. References a parameter declared in plugininfo.json." TextWrapping="Wrap" />
                 </StackPanel>
             </Border>
@@ -108,6 +108,7 @@
                     <TextBlock Text="The launcher rejects plugin file paths that are absolute or that traverse outside the plugin folder." TextWrapping="Wrap" />
                     <TextBlock Text="plugininfo.json must list files that actually exist in the archive." TextWrapping="Wrap" />
                     <TextBlock Text="multiplyExisting only works on numeric columns and requires either parameterKey or updatedValue." TextWrapping="Wrap" />
+                    <TextBlock Text="append requires either parameterKey or updatedValue and works on any column type." TextWrapping="Wrap" />
                     <TextBlock Text="Unknown parameters and unknown target columns are reported as plugin errors." TextWrapping="Wrap" />
                 </StackPanel>
             </Border>
@@ -118,7 +119,7 @@
                     <TextBlock Classes="section-title"
                                Text="Current Limits" />
                     <TextBlock Text="Only skills.txt and cubemain.txt are supported today." TextWrapping="Wrap" />
-                    <TextBlock Text="replace and multiplyExisting are the only supported operations." TextWrapping="Wrap" />
+                    <TextBlock Text="replace, multiplyExisting, and append are the supported operations." TextWrapping="Wrap" />
                     <TextBlock Text="Values are written through the generated parser types, so the column name and value type still need to be valid." TextWrapping="Wrap" />
                 </StackPanel>
             </Border>

--- a/ReimaginedLauncher/Views/Plugins/PluginAuthoringGuideView.axaml.cs
+++ b/ReimaginedLauncher/Views/Plugins/PluginAuthoringGuideView.axaml.cs
@@ -49,6 +49,13 @@ public partial class PluginAuthoringGuideView : UserControl
                                                  "rowIdentifier": "Socketed Magic Weapon",
                                                  "column": "NumMods",
                                                  "updatedValue": "2"
+                                               },
+                                               {
+                                                 "file": "skills.txt",
+                                                 "rowIdentifier": "amazonlightningfury",
+                                                 "column": "EMin",
+                                                 "operation": "append",
+                                                 "updatedValue": "+10*20"
                                                }
                                              ]
                                              """;

--- a/ReimaginedLauncher/Views/Plugins/PluginAuthoringGuideView.axaml.cs
+++ b/ReimaginedLauncher/Views/Plugins/PluginAuthoringGuideView.axaml.cs
@@ -53,7 +53,7 @@ public partial class PluginAuthoringGuideView : UserControl
                                                {
                                                  "file": "skills.txt",
                                                  "rowIdentifier": "amazonlightningfury",
-                                                 "column": "EMin",
+                                                 "column": "calc1",
                                                  "operation": "append",
                                                  "updatedValue": "+10*20"
                                                }


### PR DESCRIPTION
Adds the `append` operator for use alongside replace and multiplyexisting

Wraps the .txt cell entry in `(` and `)` and adds the users updateexisting or paramkey value afterwards. This will at minimum result in a multiplication operation but can be used to add a `+` `-` `*` `/` additional math to an existing formulae without breaking it.