### PR TITLE
feat(#98): Save Transfer Support via Select Zip

### DIFF
--- a/ReimaginedLauncher/Utilities/BackupService.cs
+++ b/ReimaginedLauncher/Utilities/BackupService.cs
@@ -320,6 +320,60 @@ public static class BackupService
         }
     }
 
+    public static async Task<bool> RestoreBackupFromArchiveAsync(string? archivePath)
+    {
+        if (string.IsNullOrWhiteSpace(archivePath) || !File.Exists(archivePath))
+        {
+            Notifications.SendNotification("Select a valid .zip file to restore.", "Warning");
+            return false;
+        }
+
+        if (!string.Equals(Path.GetExtension(archivePath), ".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            Notifications.SendNotification("Backup archive must be a .zip file.", "Warning");
+            return false;
+        }
+
+        var destinationDirectory = GetResolvedSaveDirectory();
+        if (string.IsNullOrWhiteSpace(destinationDirectory))
+        {
+            Notifications.SendNotification("Save directory could not be resolved from modinfo.json.", "Warning");
+            return false;
+        }
+
+        if (!ArchiveContainsSaveFiles(archivePath))
+        {
+            Notifications.SendNotification("Selected zip does not contain any .d2i or .d2s save files.", "Warning");
+            return false;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(destinationDirectory);
+            var errors = await ExtractArchiveAsync(archivePath, destinationDirectory);
+
+            if (errors.Count > 0)
+            {
+                var errorSummary = string.Join(Environment.NewLine, errors.Take(3));
+                if (errors.Count > 3)
+                {
+                    errorSummary += $"{Environment.NewLine}...and {errors.Count - 3} more files failed.";
+                }
+
+                Notifications.SendNotification($"Restored backup with errors:{Environment.NewLine}{errorSummary}", "Warning");
+                return true;
+            }
+
+            Notifications.SendNotification($"Restored backup from: {Path.GetFileName(archivePath)}", "Success");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Notifications.SendNotification($"Restore failed: {ex.Message}", "Warning");
+            return false;
+        }
+    }
+
     public static void EnforceBackupLimit()
     {
         TrimBackups();
@@ -547,6 +601,29 @@ public static class BackupService
 
             return errors;
         });
+    }
+
+    private static bool ArchiveContainsSaveFiles(string archivePath)
+    {
+        try
+        {
+            using var archive = ZipFile.OpenRead(archivePath);
+            return archive.Entries.Any(entry =>
+            {
+                if (string.IsNullOrEmpty(entry.Name))
+                {
+                    return false;
+                }
+
+                var extension = Path.GetExtension(entry.Name);
+                return string.Equals(extension, ".d2i", StringComparison.OrdinalIgnoreCase)
+                       || string.Equals(extension, ".d2s", StringComparison.OrdinalIgnoreCase);
+            });
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static int GetArchiveFileCount(string archivePath)

--- a/ReimaginedLauncher/Views/Backups/BackupsView.axaml
+++ b/ReimaginedLauncher/Views/Backups/BackupsView.axaml
@@ -85,6 +85,9 @@
             <StackPanel Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="8">
                 <Button Content="Take Backup Now" Click="OnTakeBackupNowClick"/>
                 <Button Content="Restore Selected" Click="OnRestoreSelectedClick"/>
+                <Button Content="Select Zip"
+                        ToolTip.Tip="Restore from a .zip backup outside the backup folder."
+                        Click="OnRestoreFromZipClick"/>
                 <Button Content="Refresh" Click="OnRefreshClick"/>
             </StackPanel>
 

--- a/ReimaginedLauncher/Views/Backups/BackupsView.axaml.cs
+++ b/ReimaginedLauncher/Views/Backups/BackupsView.axaml.cs
@@ -125,6 +125,36 @@ public partial class BackupsView : UserControl
         }
     }
 
+    private async void OnRestoreFromZipClick(object? sender, RoutedEventArgs e)
+    {
+        if (TopLevel.GetTopLevel(this) is not Window window)
+        {
+            return;
+        }
+
+        var zipFileType = new FilePickerFileType("Zip archives")
+        {
+            Patterns = new[] { "*.zip" }
+        };
+
+        var files = await window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Select Backup Zip",
+            AllowMultiple = false,
+            FileTypeFilter = new[] { zipFileType }
+        });
+
+        if (files.Count <= 0)
+        {
+            return;
+        }
+
+        if (await BackupService.RestoreBackupFromArchiveAsync(files[0].Path.LocalPath))
+        {
+            RefreshBackupState();
+        }
+    }
+
     private void OnRefreshClick(object? sender, RoutedEventArgs e)
     {
         RefreshBackupState();


### PR DESCRIPTION
Resolves: #98

Allows user to select a .zip file to transfer into their save folder that checks for the existence of at least 1 .d2i or .d2s file inside or the .zip is rejected.

<img width="1498" height="677" alt="image" src="https://github.com/user-attachments/assets/26ad68de-b977-4455-a405-118651d0b668" />
