### PR TITLE
feat: Introduce more robust plugin cleanup handling

### DIFF
--- a/ReimaginedLauncher/App.axaml
+++ b/ReimaginedLauncher/App.axaml
@@ -144,7 +144,7 @@
             <Setter Property="Background" Value="#0B0909" />
             <Setter Property="Foreground" Value="{StaticResource TextBrush}" />
             <Setter Property="BorderBrush" Value="{StaticResource BorderStrongBrush}" />
-            <Setter Property="FontFamily" Value="Cascadia Code" />
+            <Setter Property="FontFamily" Value="Cascadia Mono, Consolas, Menlo, monospace" />
             <Setter Property="FontSize" Value="13" />
             <Setter Property="LineNumbersForeground" Value="{StaticResource MutedTextBrush}" />
         </Style>

--- a/ReimaginedLauncher/Program.cs
+++ b/ReimaginedLauncher/Program.cs
@@ -3,6 +3,7 @@ using Avalonia;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ReimaginedLauncher.HttpClients;
+using ReimaginedLauncher.Utilities;
 using Velopack;
 
 namespace ReimaginedLauncher;
@@ -25,7 +26,13 @@ class Program
         services.AddHttpClient<NexusModsHttpClient>();
         
         ServiceProvider = services.BuildServiceProvider();
-        
+
+        // Reconcile plugin state and purge stray files before the UI comes
+        // up: drops orphan asset-backup claims for plugins no longer in
+        // settings, removes unreferenced empty subdirs under %AppData%, and
+        // clears stale plugin zip downloads from %TEMP%.
+        PluginStateSanitizer.RunStartupSanitizationAsync().GetAwaiter().GetResult();
+
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
     }
 

--- a/ReimaginedLauncher/ReimaginedLauncher.csproj
+++ b/ReimaginedLauncher/ReimaginedLauncher.csproj
@@ -23,20 +23,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="12.0.2" />
+        <PackageReference Include="Avalonia" Version="12.0.3" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
-        <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.3" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.3" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.3" />
         <PackageReference Include="AvaloniaEdit.TextMate" Version="12.0.0" />
         <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="D2RReimaginedTools.FileExtensions" Version="0.5.6" />
+        <PackageReference Include="D2RReimaginedTools.FileExtensions" Version="0.6.0" />
         <PackageReference Include="Material.Icons.Avalonia" Version="3.0.2" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
         <PackageReference Include="Velopack" Version="$(VelopackVersion)" />
     </ItemGroup>
 

--- a/ReimaginedLauncher/Utilities/PluginAssetBackupService.cs
+++ b/ReimaginedLauncher/Utilities/PluginAssetBackupService.cs
@@ -269,6 +269,97 @@ public static class PluginAssetBackupService
         }
     }
 
+    /// <summary>
+    /// Startup safety net: drops claims for plugin ids that no longer exist
+    /// in settings, restores any entry left with zero claimants, and prunes
+    /// orphan backup payload folders. Closes the hole where a plugin is
+    /// removed from settings (or deleted from disk) without going through
+    /// <see cref="RestoreForPluginAsync"/>, which would otherwise leave its
+    /// targets permanently mutated in the user's mod folder.
+    /// </summary>
+    public static async Task ReconcileWithKnownPluginIdsAsync(IEnumerable<string> knownPluginIds)
+    {
+        var known = new HashSet<string>(
+            knownPluginIds ?? Array.Empty<string>(),
+            StringComparer.OrdinalIgnoreCase);
+
+        await ServiceLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var manifest = LoadManifestUnsafe();
+            if (manifest.Entries.Count == 0)
+            {
+                CleanupOrphanGuidFoldersUnsafe(manifest);
+                return;
+            }
+
+            var dirty = false;
+
+            foreach (var entry in manifest.Entries)
+            {
+                var retained = entry.ClaimingPluginIds
+                    .Where(id => known.Contains(id))
+                    .ToList();
+
+                if (retained.Count == entry.ClaimingPluginIds.Count)
+                {
+                    continue;
+                }
+
+                if (retained.Count > 0)
+                {
+                    entry.ClaimingPluginIds = retained;
+                    dirty = true;
+                    continue;
+                }
+
+                try
+                {
+                    if (entry.OriginalExisted &&
+                        !string.IsNullOrWhiteSpace(entry.BackupAbsolutePath) &&
+                        File.Exists(entry.BackupAbsolutePath))
+                    {
+                        var destinationFolder = Path.GetDirectoryName(entry.TargetAbsolutePath);
+                        if (!string.IsNullOrWhiteSpace(destinationFolder))
+                        {
+                            Directory.CreateDirectory(destinationFolder);
+                        }
+
+                        await FileCopyHelper.CopyFileAsync(entry.BackupAbsolutePath, entry.TargetAbsolutePath)
+                            .ConfigureAwait(false);
+                        TryDeleteFile(entry.BackupAbsolutePath);
+                    }
+                    else if (!entry.OriginalExisted && File.Exists(entry.TargetAbsolutePath))
+                    {
+                        TryDeleteFile(entry.TargetAbsolutePath);
+                    }
+
+                    entry.ClaimingPluginIds = retained;
+                    dirty = true;
+                }
+                catch (Exception ex)
+                {
+                    LaunchDiagnostics.LogException(
+                        $"Failed to restore orphaned plugin asset '{entry.TargetAbsolutePath}'", ex);
+                    // Keep the original claim ids so the next startup can
+                    // retry the restore instead of losing the backup.
+                }
+            }
+
+            if (dirty)
+            {
+                manifest.Entries.RemoveAll(entry => entry.ClaimingPluginIds.Count == 0);
+                SaveManifestUnsafe(manifest);
+            }
+
+            CleanupOrphanGuidFoldersUnsafe(manifest);
+        }
+        finally
+        {
+            ServiceLock.Release();
+        }
+    }
+
     private static async Task CaptureSnapshotAsync(PluginAssetBackupEntry entry, string targetPath)
     {
         if (File.Exists(targetPath))

--- a/ReimaginedLauncher/Utilities/PluginStateSanitizer.cs
+++ b/ReimaginedLauncher/Utilities/PluginStateSanitizer.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ReimaginedLauncher.Utilities;
+
+/// <summary>
+/// Startup-time housekeeping for plugin-related on-disk state. Reconciles the
+/// asset backup manifest against the plugins currently registered in
+/// settings, prunes unreferenced empty subdirectories under
+/// <c>%AppData%\ReimaginedLauncher\plugins</c> and
+/// <c>plugin-asset-backups</c>, and clears stale plugin zip downloads left
+/// behind in <c>%TEMP%</c>.
+/// </summary>
+public static class PluginStateSanitizer
+{
+    private const string TempPluginDownloadsRoot = "d2r-reimagined-launcher";
+
+    public static async Task RunStartupSanitizationAsync()
+    {
+        try
+        {
+            var settings = await SettingsManager.LoadAsync().ConfigureAwait(false);
+
+            var knownIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var knownFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var profile in settings.Profiles)
+            {
+                foreach (var registration in profile.Plugins)
+                {
+                    if (!string.IsNullOrWhiteSpace(registration.Id))
+                    {
+                        knownIds.Add(registration.Id);
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(registration.FolderName))
+                    {
+                        knownFolders.Add(registration.FolderName);
+                    }
+                }
+            }
+
+            await PluginAssetBackupService.ReconcileWithKnownPluginIdsAsync(knownIds).ConfigureAwait(false);
+
+            RemoveUnreferencedEmptySubdirectories(PluginsService.PluginsDirectoryPath, knownFolders);
+            RemoveUnreferencedEmptyBackupSubdirectories();
+            ClearTempPluginDownloads();
+        }
+        catch (Exception ex)
+        {
+            LaunchDiagnostics.LogException("Plugin state sanitization failed", ex);
+        }
+    }
+
+    private static void RemoveUnreferencedEmptySubdirectories(string root, ICollection<string> referencedNames)
+    {
+        if (!Directory.Exists(root))
+        {
+            return;
+        }
+
+        IEnumerable<string> subdirs;
+        try
+        {
+            subdirs = Directory.EnumerateDirectories(root).ToList();
+        }
+        catch (Exception ex)
+        {
+            LaunchDiagnostics.LogException($"Failed to enumerate '{root}' for sanitization", ex);
+            return;
+        }
+
+        foreach (var dir in subdirs)
+        {
+            var name = Path.GetFileName(dir);
+            if (referencedNames.Contains(name))
+            {
+                continue;
+            }
+
+            TryDeleteIfEmpty(dir);
+        }
+    }
+
+    private static void RemoveUnreferencedEmptyBackupSubdirectories()
+    {
+        // Backup payload folders are GUID-named and managed by
+        // PluginAssetBackupService's own orphan sweep, which has already run
+        // by this point. Anything still empty here is unreferenced by
+        // design, so prune it.
+        var root = PluginAssetBackupService.BackupRootDirectory;
+        if (!Directory.Exists(root))
+        {
+            return;
+        }
+
+        IEnumerable<string> subdirs;
+        try
+        {
+            subdirs = Directory.EnumerateDirectories(root).ToList();
+        }
+        catch (Exception ex)
+        {
+            LaunchDiagnostics.LogException($"Failed to enumerate '{root}' for sanitization", ex);
+            return;
+        }
+
+        foreach (var dir in subdirs)
+        {
+            TryDeleteIfEmpty(dir);
+        }
+    }
+
+    private static void TryDeleteIfEmpty(string directory)
+    {
+        try
+        {
+            if (!Directory.Exists(directory))
+            {
+                return;
+            }
+
+            if (Directory.EnumerateFileSystemEntries(directory).Any())
+            {
+                return;
+            }
+
+            Directory.Delete(directory);
+        }
+        catch (Exception ex)
+        {
+            LaunchDiagnostics.LogException($"Failed to delete empty plugin subdirectory '{directory}'", ex);
+        }
+    }
+
+    private static void ClearTempPluginDownloads()
+    {
+        string tempRoot;
+        try
+        {
+            tempRoot = Path.Combine(Path.GetTempPath(), TempPluginDownloadsRoot);
+        }
+        catch (Exception ex)
+        {
+            LaunchDiagnostics.LogException("Failed to resolve temp path for plugin download cleanup", ex);
+            return;
+        }
+
+        if (!Directory.Exists(tempRoot))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+        catch (Exception ex)
+        {
+            LaunchDiagnostics.LogException(
+                $"Failed to clear stale plugin download cache '{tempRoot}'", ex);
+        }
+    }
+}

--- a/ReimaginedLauncher/Utilities/PluginsService.cs
+++ b/ReimaginedLauncher/Utilities/PluginsService.cs
@@ -843,9 +843,20 @@ public static class PluginsService
             var pluginState = await LoadPluginStateAsync(registration);
             if (pluginState.Errors.Count > 0)
             {
-                var message = $"Plugin '{pluginState.Name}' is invalid and was skipped.";
-                ReportProgress(progress, message);
-                Notifications.SendNotification(message, "Warning");
+                var summary = $"Plugin '{pluginState.Name}' is invalid and was skipped.";
+                ReportProgress(progress, summary);
+                Notifications.SendNotification(summary, "Warning");
+                // Surface each validation error so authors see the actual cause
+                // (unsupported operation, unknown column, malformed condition, etc.)
+                // instead of only a generic "skipped" toast.
+                foreach (var error in pluginState.Errors)
+                {
+                    ReportProgress(progress, $"Plugin '{pluginState.Name}' error: {error}");
+                    Notifications.SendNotification($"Plugin '{pluginState.Name}': {error}", "Warning");
+                    LaunchDiagnostics.LogException(
+                        $"Plugin '{pluginState.Name}' validation error",
+                        new InvalidDataException(error));
+                }
                 continue;
             }
 
@@ -3898,7 +3909,7 @@ public static class PluginsService
             }
         }
 
-        return operation with
+        var normalized = operation with
         {
             File = NormalizeRelativePath(operation.File ?? string.Empty),
             RowIdentifier = operation.RowIdentifier?.Trim() ?? string.Empty,
@@ -3914,6 +3925,71 @@ public static class PluginsService
             SwapRowIdentifier = operation.SwapRowIdentifier?.Trim(),
             SwapColumns = normalizedSwapColumns
         };
+
+        // Reject literal tab characters in any value that flows into a TSV cell
+        // (column name, row identifier, or updated value). A stray tab -- usually
+        // pasted from a spreadsheet -- would silently split into extra columns
+        // when the excel file is rewritten by File.WriteAllLinesAsync with
+        // string.Join('\t', ...). JSON-only fields (LanguageValues) are not
+        // checked here because tabs are legal in JSON string values.
+        RejectTabCharacter(normalized.RowIdentifier, "rowIdentifier", normalized.File);
+        RejectTabCharacter(normalized.Column, "column", normalized.File);
+        RejectTabCharacter(normalized.UpdatedValue, "updatedValue", normalized.File);
+        RejectTabCharacter(normalized.SourceRowIdentifier, "sourceRowIdentifier", normalized.File);
+        RejectTabCharacter(normalized.SwapRowIdentifier, "swapRowIdentifier", normalized.File);
+        if (normalized.RowIdentifiers != null)
+        {
+            foreach (var pair in normalized.RowIdentifiers)
+            {
+                RejectTabCharacter(pair.Value, $"rowIdentifier.{pair.Key}", normalized.File);
+            }
+        }
+        if (normalized.RowMatchers != null)
+        {
+            foreach (var matcher in normalized.RowMatchers)
+            {
+                RejectTabCharacter(matcher.Value, "rowIdentifier", normalized.File);
+                if (matcher.Columns != null)
+                {
+                    foreach (var pair in matcher.Columns)
+                    {
+                        RejectTabCharacter(pair.Value, $"rowIdentifier.{pair.Key}", normalized.File);
+                    }
+                }
+            }
+        }
+        if (normalized.Columns != null)
+        {
+            foreach (var column in normalized.Columns)
+            {
+                RejectTabCharacter(column.Column, "columns.column", normalized.File);
+                RejectTabCharacter(column.UpdatedValue, $"columns.{column.Column}.updatedValue", normalized.File);
+            }
+        }
+        if (normalized.SwapColumns != null)
+        {
+            foreach (var column in normalized.SwapColumns)
+            {
+                RejectTabCharacter(column.Column, "swapColumns.column", normalized.File);
+                RejectTabCharacter(column.UpdatedValue, $"swapColumns.{column.Column}.updatedValue", normalized.File);
+            }
+        }
+
+        return normalized;
+    }
+
+    private static void RejectTabCharacter(string? value, string fieldName, string? file)
+    {
+        if (value == null || value.IndexOf('\t') < 0)
+        {
+            return;
+        }
+
+        var location = string.IsNullOrWhiteSpace(file) ? string.Empty : $" in '{file}'";
+        throw new InvalidDataException(
+            $"Plugin operation field '{fieldName}'{location} contains a tab character. " +
+            "Tabs are not allowed because they would split values into extra columns when " +
+            "the target excel file is rewritten. Replace the tab with spaces.");
     }
 
     private static PluginRegistration GetRegistration(string pluginId)


### PR DESCRIPTION
Fix plugins remnants not being cleaned up on removal or when manually removed without launcher intervention and attempt to clean up temp remnants causing artifacts in plugins which result in unintended changed.

File was too large for this so uploaded to OneDrive:
[OneDrive Test Zip](https://1drv.ms/u/c/8fd2c2d236504364/IQD29lQFISjeQ77TqyN0DDQeATbRfd9-kwyK7_C-wciJQQY?e=t72eSF)