### PR TITLE
Disable automatic launcher updates check box

### DIFF
--- a/ReimaginedLauncher/MainWindow.axaml.cs
+++ b/ReimaginedLauncher/MainWindow.axaml.cs
@@ -195,6 +195,7 @@ public partial class MainWindow : Window
         await SettingsManager.SaveAsync(Settings);
 
         await RefreshUpdateStateAsync();
+        LauncherUpdateService.AreUpdatesDisabled = Settings.DisableLauncherUpdates;
         _ = LauncherUpdateService.CheckForUpdatesAsync();
         StartLauncherUpdateCheckTimer();
 
@@ -1165,6 +1166,14 @@ public partial class MainWindow : Window
     // click feels acknowledged regardless of whether an update is available.
     private async void OnLauncherVersionClicked(object? sender, Avalonia.Input.PointerPressedEventArgs e)
     {
+        if (LauncherUpdateService.AreUpdatesDisabled)
+        {
+            Notifications.SendNotification(
+                "Automatic launcher updates are disabled. Enable them in Settings to check for updates.",
+                "Launcher");
+            return;
+        }
+
         try
         {
             Notifications.SendNotification("Checking for launcher updates...", "Launcher");

--- a/ReimaginedLauncher/Utilities/AppSettings.cs
+++ b/ReimaginedLauncher/Utilities/AppSettings.cs
@@ -61,6 +61,7 @@ public class AppSettings
     public double UiScale { get; set; } = 1.0;
     public bool MinimizeToTray { get; set; }
     public bool MinimizeToTrayOnClose { get; set; }
+    public bool DisableLauncherUpdates { get; set; }
     public double? WindowWidth { get; set; }
     public double? WindowHeight { get; set; }
     public double? WindowX { get; set; }

--- a/ReimaginedLauncher/Utilities/LauncherUpdateService.cs
+++ b/ReimaginedLauncher/Utilities/LauncherUpdateService.cs
@@ -17,13 +17,20 @@ public static class LauncherUpdateService
     public static bool IsUpdateAvailable { get; private set; }
     public static bool IsDownloading { get; private set; }
     public static bool IsUpdateDownloaded { get; private set; }
+
+    // When true, all automatic update behavior is suppressed: update checks (startup,
+    // hourly poll, and the version-label click) are skipped, no update is downloaded so
+    // no reminder banner appears, and any previously downloaded update is never applied
+    // on close/restart. Driven by the "Disable automatic launcher updates" setting.
+    public static bool AreUpdatesDisabled { get; set; }
+
     public static string? LatestVersion { get; private set; }
     public static event EventHandler? UpdateDownloaded;
     public static event EventHandler? UpdateStateChanged;
 
     public static async Task CheckForUpdatesAsync()
     {
-        if (_hasCheckedForUpdates || !OperatingSystem.IsWindows())
+        if (AreUpdatesDisabled || _hasCheckedForUpdates || !OperatingSystem.IsWindows())
         {
             return;
         }
@@ -74,6 +81,11 @@ public static class LauncherUpdateService
 
     public static void ApplyUpdateAndRestart()
     {
+        if (AreUpdatesDisabled)
+        {
+            return;
+        }
+
         if (_updateManager != null && _updateInfo != null && IsUpdateDownloaded)
         {
             _updateManager.ApplyUpdatesAndRestart(_updateInfo);

--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml
@@ -135,6 +135,23 @@
                     </StackPanel>
                 </StackPanel>
             </Border>
+
+            <Border Classes="panel"
+                    Padding="20">
+                <StackPanel Spacing="14">
+                    <TextBlock Classes="section-title"
+                               Text="Launcher Updates" />
+                    <StackPanel Spacing="4">
+                        <CheckBox x:Name="DisableLauncherUpdatesCheckBox"
+                                  Content="Disable automatic launcher updates"
+                                  IsCheckedChanged="OnDisableLauncherUpdatesChanged"/>
+                        <TextBlock Classes="muted"
+                                   Margin="28,0,0,0"
+                                   TextWrapping="Wrap"
+                                   Text="Stops the launcher from checking for, downloading, reminding about, or installing its own updates, including the version-label update check. Uncheck this to allow updates again." />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
@@ -52,6 +52,7 @@ public partial class SettingsView : UserControl
 
         MinimizeToTrayCheckBox.IsChecked = MainWindow.Settings.MinimizeToTray;
         MinimizeToTrayOnCloseCheckBox.IsChecked = MainWindow.Settings.MinimizeToTrayOnClose;
+        DisableLauncherUpdatesCheckBox.IsChecked = MainWindow.Settings.DisableLauncherUpdates;
 
         _isRefreshingSettings = false;
     }
@@ -107,6 +108,19 @@ public partial class SettingsView : UserControl
         }
 
         MainWindow.Settings.MinimizeToTrayOnClose = MinimizeToTrayOnCloseCheckBox.IsChecked ?? false;
+        await SettingsManager.SaveAsync(MainWindow.Settings);
+    }
+
+    private async void OnDisableLauncherUpdatesChanged(object? sender, RoutedEventArgs e)
+    {
+        if (_isRefreshingSettings)
+        {
+            return;
+        }
+
+        var disabled = DisableLauncherUpdatesCheckBox.IsChecked ?? false;
+        MainWindow.Settings.DisableLauncherUpdates = disabled;
+        LauncherUpdateService.AreUpdatesDisabled = disabled;
         await SettingsManager.SaveAsync(MainWindow.Settings);
     }
 


### PR DESCRIPTION
Resolves: #10 

Adds a checkbox in settings that completely disables automatic updates and all update behaviour.