### PR TITLE
feat: Add direct play button to launch tab nav panel

### DIFF
--- a/ReimaginedLauncher/MainWindow.axaml
+++ b/ReimaginedLauncher/MainWindow.axaml
@@ -82,7 +82,25 @@
                              Classes="nav-list"
                              SelectionChanged="OnNavigationSelectionChanged">
                         <ListBoxItem x:Name="NewsAnnouncementsNavItem" Tag="NewsAnnouncements" Content="News &amp; Announcements" />
-                        <ListBoxItem x:Name="LaunchNavItem" Tag="Launch" Content="Launch" />
+                        <ListBoxItem x:Name="LaunchNavItem" Tag="Launch" HorizontalContentAlignment="Stretch">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <TextBlock Grid.Column="0"
+                                           Text="Launch"
+                                           VerticalAlignment="Center" />
+                                <Button Grid.Column="1"
+                                        Classes="accent"
+                                        Padding="8,2"
+                                        MinWidth="0"
+                                        MinHeight="0"
+                                        VerticalAlignment="Center"
+                                        ToolTip.Tip="Start Game"
+                                        Click="OnLaunchNavPlayClicked">
+                                    <materialIcons:MaterialIcon Kind="Play"
+                                                                Width="16"
+                                                                Height="16" />
+                                </Button>
+                            </Grid>
+                        </ListBoxItem>
                         <ListBoxItem x:Name="UpdateNavItem" Tag="Update" Content="Install/Update" />
                         <ListBoxItem x:Name="BackupsNavItem" Tag="Backups" Content="Backups" />
                         <ListBoxItem x:Name="SettingsNavItem" Tag="Settings" Content="Settings" />

--- a/ReimaginedLauncher/MainWindow.axaml.cs
+++ b/ReimaginedLauncher/MainWindow.axaml.cs
@@ -735,6 +735,17 @@ public partial class MainWindow : Window
         }
     }
 
+    // Play shortcut on the Launch navigation item: runs the same sequence as the
+    // Start Game button without leaving the current view. If the Launch view is
+    // already showing we reuse it (so its status UI updates); otherwise we drive a
+    // transient instance, which still launches because StartGameAsync resolves the
+    // window via MainWindow.Instance rather than its own visual tree.
+    private async void OnLaunchNavPlayClicked(object? sender, RoutedEventArgs e)
+    {
+        var launchView = ContentArea.Content as LaunchView ?? new LaunchView();
+        await launchView.StartGameAsync();
+    }
+
     private void SetUpdateState(
         bool isUpdateAvailable,
         bool canInstallOrUpdate,

--- a/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
+++ b/ReimaginedLauncher/Views/Launch/LaunchView.axaml.cs
@@ -233,6 +233,14 @@ public partial class LaunchView : UserControl
 
     private async void OnRunClick(object? sender, RoutedEventArgs e)
     {
+        await StartGameAsync();
+    }
+
+    // Runs the same prepare-backup-launch sequence as the Start Game button.
+    // Exposed so callers outside this view (e.g. the navigation Play shortcut)
+    // can trigger a launch directly.
+    public async Task StartGameAsync()
+    {
         LaunchDiagnostics.ResetSession();
         LaunchDiagnostics.Log("Launch/Install button clicked.");
 
@@ -260,7 +268,7 @@ public partial class LaunchView : UserControl
                 "D2R Reimagined mod not detected",
                 "Install the mod in the selected directory before launching/installing.");
 
-            if (TopLevel.GetTopLevel(this) is MainWindow mainWindow)
+            if (MainWindow.Instance is { } mainWindow)
             {
                 await mainWindow.PromptInstallForMissingModAsync();
             }
@@ -314,7 +322,7 @@ public partial class LaunchView : UserControl
                     LaunchDiagnostics.Log("GameLauncherService.LaunchGame returned without throwing.");
                     SetLaunchStatus($"{actionName} command sent.");
 
-                    if (gameProcess != null && MainWindow.Settings.MinimizeToTray && TopLevel.GetTopLevel(this) is MainWindow mainWindow)
+                    if (gameProcess != null && MainWindow.Settings.MinimizeToTray && MainWindow.Instance is { } mainWindow)
                     {
                         // For Steam launches, pass the actual D2R.exe path so the launcher
                         // waits for the game process rather than the Steam bootstrapper.


### PR DESCRIPTION
Resolves: #191 

Let me know if this is sufficient. It performs all the checks and operations the button on the launch panel does, but doesn't swap to that tab or require you to in order to launch the game. Made it big enough to easily click, but small enough that you won't hit it by accident trying to change to the tab to swap profiles.

<img width="368" height="364" alt="image" src="https://github.com/user-attachments/assets/3d2ce754-5e98-4cf2-b0cf-d94e1b16bd6f" />