### PR TITLE
Fix scroll jump after saving text plugin parameters

### DIFF
--- a/ReimaginedLauncher/Views/Plugins/PluginsView.axaml.cs
+++ b/ReimaginedLauncher/Views/Plugins/PluginsView.axaml.cs
@@ -501,15 +501,17 @@ public partial class PluginsView : UserControl
             return;
         }
 
+        var value = (textBox.Text ?? string.Empty).Trim();
+
         try
         {
-            var changed = await PluginsService.SaveParameterValueAsync(parameter.PluginId, parameter.Key, textBox.Text ?? string.Empty);
+            var changed = await PluginsService.SaveParameterValueAsync(parameter.PluginId, parameter.Key, value);
             if (!changed)
             {
                 return;
             }
 
-            await RefreshPluginsStateAsync();
+            parameter.UpdateValue(value);
             Notifications.SendNotification("Plugin parameter saved.", "Success");
         }
         catch (Exception ex)


### PR DESCRIPTION
1. Select a dropdown option that reveals a conditional text parameter.
2. Enter a value in the text field.
3. Click outside the field.
4. The plugin catalog refreshes and the scroll position jumps.

checkbox and dropdown handlers already save without calling
`RefreshPluginsStateAsync()`. This change applies the same behavior to text
parameters.