### PR TITLE
fix issue

### DIFF
--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml
@@ -4,8 +4,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="ReimaginedLauncher.Views.Settings.SettingsView">
-    <ScrollViewer HorizontalScrollBarVisibility="Disabled"
-                  VerticalScrollBarVisibility="Auto">
+    <ScrollViewer x:Name="RootScrollViewer"
+                  HorizontalScrollBarVisibility="Disabled"
+                  VerticalScrollBarVisibility="Auto"
+                  Focusable="True">
         <StackPanel Spacing="18">
             <StackPanel Spacing="4">
                 <TextBlock Classes="view-title"
@@ -140,7 +142,14 @@
                                      Margin="28,4,0,0"
                                      HorizontalAlignment="Left"
                                      PlaceholderText="0 - 4294967295"
-                                     LostFocus="OnCustomMapSeedChanged"/>
+                                     LostFocus="OnCustomMapSeedChanged"
+                                     KeyDown="OnCustomMapSeedKeyDown"
+                                     TextChanged="OnCustomMapSeedTextChanged"/>
+                            <TextBlock x:Name="CustomMapSeedValidationText"
+                                       Margin="28,0,0,0"
+                                       Foreground="{StaticResource DangerTextBrush}"
+                                       IsVisible="False"
+                                       Text="Enter a whole number from 0 to 4294967295." />
                         </StackPanel>
                     </StackPanel>
                 </StackPanel>

--- a/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
+++ b/ReimaginedLauncher/Views/Settings/SettingsView.axaml.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using ReimaginedLauncher.Utilities;
 
 namespace ReimaginedLauncher.Views.Settings;
@@ -14,6 +15,7 @@ namespace ReimaginedLauncher.Views.Settings;
 public partial class SettingsView : UserControl
 {
     private bool _isRefreshingSettings;
+    private bool _releaseSeedFocusAfterPointerRelease;
 
     // Set by the tunnelling PointerPressed handler just before a folder button's
     // Click fires, so the handler knows whether Ctrl was held (force picker).
@@ -37,6 +39,9 @@ public partial class SettingsView : UserControl
         {
             button.AddHandler(InputElement.PointerPressedEvent, OnFolderButtonPointerPressed, RoutingStrategies.Tunnel);
         }
+
+        RootScrollViewer.AddHandler(InputElement.PointerPressedEvent, OnSettingsPointerPressed, RoutingStrategies.Tunnel);
+        RootScrollViewer.AddHandler(InputElement.PointerReleasedEvent, OnSettingsPointerReleased, RoutingStrategies.Tunnel);
 
         RefreshSettingsState();
     }
@@ -80,6 +85,7 @@ public partial class SettingsView : UserControl
         }
 
         CustomMapSeedTextBox.Text = profile.CustomMapSeed.ToString(CultureInfo.InvariantCulture);
+        CustomMapSeedValidationText.IsVisible = false;
 
         MinimizeToTrayCheckBox.IsChecked = MainWindow.Settings.MinimizeToTray;
         MinimizeToTrayOnCloseCheckBox.IsChecked = MainWindow.Settings.MinimizeToTrayOnClose;
@@ -128,27 +134,87 @@ public partial class SettingsView : UserControl
             return;
         }
 
-        if (!TryApplyCustomMapSeed())
+        await ApplyCustomMapSeedAsync();
+    }
+
+    private async void OnCustomMapSeedKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (_isRefreshingSettings || e.Key != Key.Enter)
         {
-            RefreshSettingsState();
-            Notifications.SendNotification(
-                "Custom map seed must be a whole number between 0 and 4294967295.",
-                "Warning");
             return;
         }
 
-        await SettingsManager.SaveAsync(MainWindow.Settings);
+        e.Handled = true;
+        if (await ApplyCustomMapSeedAsync())
+        {
+            RootScrollViewer.Focus();
+        }
     }
 
-    private bool TryApplyCustomMapSeed()
+    private void OnCustomMapSeedTextChanged(object? sender, TextChangedEventArgs e)
     {
+        CustomMapSeedValidationText.IsVisible = !_isRefreshingSettings && !IsCustomMapSeedValid();
+    }
+
+    private async Task<bool> ApplyCustomMapSeedAsync()
+    {
+        if (!TryApplyCustomMapSeed(out var changed))
+        {
+            return false;
+        }
+
+        if (changed)
+        {
+            await SettingsManager.SaveAsync(MainWindow.Settings);
+        }
+
+        return true;
+    }
+
+    private bool TryApplyCustomMapSeed(out bool changed)
+    {
+        changed = false;
+
         if (!uint.TryParse(CustomMapSeedTextBox.Text, CultureInfo.InvariantCulture, out var seed))
         {
             return false;
         }
 
-        MainWindow.Settings.CurrentProfile.CustomMapSeed = seed;
+        var profile = MainWindow.Settings.CurrentProfile;
+        changed = profile.CustomMapSeed != seed;
+        profile.CustomMapSeed = seed;
         return true;
+    }
+
+    private bool IsCustomMapSeedValid()
+        => uint.TryParse(CustomMapSeedTextBox.Text, CultureInfo.InvariantCulture, out _);
+
+    private async void OnSettingsPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!CustomMapSeedTextBox.IsFocused || CustomMapSeedTextBox.IsPointerOver)
+        {
+            return;
+        }
+
+        _releaseSeedFocusAfterPointerRelease = true;
+        await ApplyCustomMapSeedAsync();
+    }
+
+    private void OnSettingsPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_releaseSeedFocusAfterPointerRelease)
+        {
+            return;
+        }
+
+        _releaseSeedFocusAfterPointerRelease = false;
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (CustomMapSeedTextBox.IsFocused)
+            {
+                RootScrollViewer.Focus();
+            }
+        });
     }
 
     private async void OnMinimizeToTrayChanged(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
close #227 

<img width="535" height="218" alt="image" src="https://github.com/user-attachments/assets/5c66fae8-f9ae-48f1-8527-1e5bd180159b" />
<img width="925" height="182" alt="image" src="https://github.com/user-attachments/assets/e62ead0f-331e-4150-b861-e2163c067c7a" />

There was a bug where the warning notification wouldn't trigger even if a seed was entered incorrectly, unless the user clicked another checkbox or tab, and it failed to detect typing in real time.
Of course, while no one would practically type it in such an odd way, I think it would be much more intuitive to display it directly underneath the number input field rather than having a notification pop up on the right.