### PR TITLE
fix: guard FindWinePrefix against empty executable path

### DIFF
--- a/ReimaginedLauncher/Utilities/GameLauncherService.cs
+++ b/ReimaginedLauncher/Utilities/GameLauncherService.cs
@@ -705,12 +705,18 @@ public class GameLauncherService
 
     private static string? FindWinePrefix(string executablePath)
     {
-        if (!OperatingSystem.IsLinux())
+        if (!OperatingSystem.IsLinux() || string.IsNullOrWhiteSpace(executablePath))
         {
             return null;
         }
 
-        var directory = new DirectoryInfo(Path.GetDirectoryName(executablePath) ?? string.Empty);
+        var dir = Path.GetDirectoryName(executablePath);
+        if (string.IsNullOrWhiteSpace(dir))
+        {
+            return null;
+        }
+
+        var directory = new DirectoryInfo(dir);
         while (directory is not null)
         {
             if (string.Equals(directory.Name, "drive_c", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Fixes a crash on Linux when the install directory is null or empty, causing `Path.GetDirectoryName` to return an empty string and `DirectoryInfo` to throw `ArgumentException`.

Stacktrace:
```
System.ArgumentException: The value cannot be an empty string. (Parameter 'path')
   at System.IO.Path.GetFullPath(String path)
   at System.IO.DirectoryInfo..ctor(String path)
   at ReimaginedLauncher.Utilities.GameLauncherService.FindWinePrefix(String executablePath)
```